### PR TITLE
Support async activate/deactivate hooks

### DIFF
--- a/lib/addons/AddonManager.d.ts
+++ b/lib/addons/AddonManager.d.ts
@@ -36,8 +36,8 @@ export declare class AddonManager {
     static create(kairo: Kairo): AddonManager;
     getSelfAddonProperty(): AddonProperty;
     subscribeReceiverHooks(): void;
-    _activateAddon(): void;
-    _deactivateAddon(): void;
+    _activateAddon(): Promise<void>;
+    _deactivateAddon(): Promise<void>;
     _scriptEvent(data: KairoCommand): Promise<void | KairoResponse>;
     get isActive(): boolean;
     setActiveState(state: boolean): void;

--- a/lib/addons/Kairo.d.ts
+++ b/lib/addons/Kairo.d.ts
@@ -44,8 +44,8 @@ export declare class Kairo {
     static addScriptEvent(fn: ScriptEventListener, opt?: HandlerOptions): void;
     static addTick(fn: TickHandler, opt?: HandlerOptions): void;
     _scriptEvent(data: KairoCommand): Promise<void | KairoResponse>;
-    _activateAddon(): void;
-    _deactivateAddon(): void;
+    _activateAddon(): Promise<void>;
+    _deactivateAddon(): Promise<void>;
     private static _pushSorted;
     private static _runActivateHooks;
     private static _runDeactivateHooks;

--- a/lib/index.js
+++ b/lib/index.js
@@ -510,10 +510,10 @@ var AddonReceiver = class _AddonReceiver {
       }
       switch (message) {
         case SCRIPT_EVENT_MESSAGES.ACTIVATE_REQUEST:
-          this.addonManager._activateAddon();
+          await this.addonManager._activateAddon();
           break;
         case SCRIPT_EVENT_MESSAGES.DEACTIVATE_REQUEST:
-          this.addonManager._deactivateAddon();
+          await this.addonManager._deactivateAddon();
           break;
         default:
           let data;
@@ -573,11 +573,11 @@ var AddonManager = class _AddonManager {
       this.receiver.handleScriptEvent
     );
   }
-  _activateAddon() {
-    this.kairo._activateAddon();
+  async _activateAddon() {
+    await this.kairo._activateAddon();
   }
-  _deactivateAddon() {
-    this.kairo._deactivateAddon();
+  async _deactivateAddon() {
+    await this.kairo._deactivateAddon();
   }
   async _scriptEvent(data) {
     return this.kairo._scriptEvent(data);
@@ -682,11 +682,11 @@ var Kairo = class _Kairo {
   async _scriptEvent(data) {
     return _Kairo._runScriptEvent(data);
   }
-  _activateAddon() {
-    void _Kairo._runActivateHooks();
+  async _activateAddon() {
+    await _Kairo._runActivateHooks();
   }
-  _deactivateAddon() {
-    void _Kairo._runDeactivateHooks();
+  async _deactivateAddon() {
+    await _Kairo._runDeactivateHooks();
   }
   static _pushSorted(arr, fn, opt) {
     arr.push({ fn, priority: opt?.priority ?? 0 });

--- a/src/addons/AddonManager.ts
+++ b/src/addons/AddonManager.ts
@@ -58,12 +58,12 @@ export class AddonManager {
     );
   }
 
-  public _activateAddon(): void {
-    this.kairo._activateAddon();
+  public async _activateAddon(): Promise<void> {
+    await this.kairo._activateAddon();
   }
 
-  public _deactivateAddon(): void {
-    this.kairo._deactivateAddon();
+  public async _deactivateAddon(): Promise<void> {
+    await this.kairo._deactivateAddon();
   }
 
   public async _scriptEvent(data: KairoCommand): Promise<void | KairoResponse> {

--- a/src/addons/Kairo.ts
+++ b/src/addons/Kairo.ts
@@ -124,12 +124,12 @@ export class Kairo {
     return Kairo._runScriptEvent(data);
   }
 
-  public _activateAddon(): void {
-    void Kairo._runActivateHooks();
+  public async _activateAddon(): Promise<void> {
+    await Kairo._runActivateHooks();
   }
 
-  public _deactivateAddon(): void {
-    void Kairo._runDeactivateHooks();
+  public async _deactivateAddon(): Promise<void> {
+    await Kairo._runDeactivateHooks();
   }
 
   private static _pushSorted<T>(arr: Stored<T>[], fn: T, opt?: HandlerOptions) {

--- a/src/addons/router/AddonReceiver.ts
+++ b/src/addons/router/AddonReceiver.ts
@@ -33,10 +33,10 @@ export class AddonReceiver {
 
     switch (message) {
       case SCRIPT_EVENT_MESSAGES.ACTIVATE_REQUEST:
-        this.addonManager._activateAddon();
+        await this.addonManager._activateAddon();
         break;
       case SCRIPT_EVENT_MESSAGES.DEACTIVATE_REQUEST:
-        this.addonManager._deactivateAddon();
+        await this.addonManager._deactivateAddon();
         break;
       default:
         let data: any;


### PR DESCRIPTION
### Motivation
- Allow handlers passed to `onActivate`/`onDeactivate` to be `async` and ensure the framework waits for them to finish before proceeding.
- Propagate async behavior through the call chain so activation/deactivation script events are handled reliably.

### Description
- Made `Kairo._activateAddon` and `Kairo._deactivateAddon` return `Promise<void>` and `await` `_runActivateHooks` / `_runDeactivateHooks`.
- Updated `AddonManager._activateAddon` and `AddonManager._deactivateAddon` to be `async` and `await` the `Kairo` methods.
- Updated `AddonReceiver.handleScriptEvent` to `await` manager activation/deactivation when receiving `ACTIVATE_REQUEST` / `DEACTIVATE_REQUEST`.
- Updated compiled artifacts and type declarations in `lib/` (`lib/index.js`, `lib/addons/*.d.ts`) to match the new async signatures.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c9f0f36883338643006084c6b864)