### PR TITLE
chore: migrate project workflow from npm to pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # Kairo-router
+
+## Development
+
+This project uses **pnpm** as the package manager.
+
+- Required pnpm version: `10.31.0`
+- Install dependencies: `pnpm install`
+- Build: `pnpm run build`
+
+The build pipeline compiles type definitions with `tsc` and bundles JavaScript with `esbuild` (`build.mjs`).

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
     "clean": "rimraf lib",
     "build:types": "tsc",
     "build:js": "node build.mjs",
-    "build": "npm run clean && npm run build:types && npm run build:js",
-    "version:patch": "npm version patch",
-    "prepublishOnly": "npm run version:patch && npm run build"
+    "build": "pnpm run clean && pnpm run build:types && pnpm run build:js",
+    "version:patch": "pnpm version patch",
+    "prepublishOnly": "pnpm run version:patch && pnpm run build"
   },
   "peerDependencies": {
     "@minecraft/server": "^2.5.0",
@@ -32,5 +32,6 @@
     "typescript": "^5.9.3",
     "esbuild": "^0.20.0",
     "rimraf": "^5.0.0"
-  }
+  },
+  "packageManager": "pnpm@10.31.0"
 }


### PR DESCRIPTION
### Motivation

- Move the project off npm to `pnpm` (target `pnpm@10.31.0`) and ensure the build flow remains compatible with the existing `esbuild`-based pipeline.

### Description

- Update `package.json` to use `pnpm` in script invocations for `build`, `version:patch`, and `prepublishOnly` instead of `npm`.
- Add the `packageManager` field with value `pnpm@10.31.0` to pin the required pnpm version.
- Update `README.md` to document `pnpm` usage and clarify that the build pipeline uses `tsc` for types and `esbuild` (`build.mjs`) for bundling.

### Testing

- Ran the build toolchain with `./node_modules/.bin/rimraf lib && ./node_modules/.bin/tsc && node build.mjs`, which completed successfully.
- Attempted `corepack prepare pnpm@10.31.0 --activate`, which failed due to registry access returning `403` so pnpm bootstrap could not be completed in this environment.
- Attempted `pnpm install --lockfile-only`, which failed with registry `403` so a `pnpm-lock.yaml` could not be generated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69acf8d7d8ac8333bb2945f5eb8e8566)