### PR TITLE
Refactor init factories to align with CQRS responsibilities

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -117,12 +117,6 @@ declare class DiscoveryQueryParser {
     private parseJson;
 }
 
-declare class DiscoveryResponder {
-    private readonly runtime;
-    private constructor(runtime: KairoRuntime);
-    respond(kairoId: string): void;
-}
-
 interface IdRegistry {
     has(id: string): boolean;
     register(id: string): void;
@@ -147,11 +141,15 @@ declare class AddonDiscoveryManager implements Disposable {
     private readonly addonProperties;
     private readonly queryParser;
     private readonly idProvider;
-    private readonly responder;
-    private constructor(addonProperties: AddonProperties, queryParser: DiscoveryQueryParser, idProvider: KairoIdProvider, responder: DiscoveryResponder);
+    private constructor(addonProperties: AddonProperties, queryParser: DiscoveryQueryParser, idProvider: KairoIdProvider);
     resolveKairoId(message: string): string;
-    handleRegistrationQuery(message: string): string;
     dispose(): void;
+}
+
+declare class DiscoveryResponder {
+    private readonly runtime;
+    private constructor(runtime: KairoRuntime);
+    respond(kairoId: string): void;
 }
 
 declare enum KairoInitEventId {
@@ -192,20 +190,18 @@ declare class RegistrationRequestParser {
     private parseJson;
 }
 
+declare class AddonRegistrationManager {
+    private readonly parser;
+    private readonly builder;
+    private constructor(parser: RegistrationRequestParser, builder: KairoRegistryBuilder);
+    resolveRegistry(message: string, kairoId: string, addonProperties: AddonProperties): KairoRegistry | undefined;
+    dispose(): void;
+}
+
 declare class RegistrationResponder {
     private readonly runtime;
     private constructor(runtime: KairoRuntime);
     respond(kairoRegistry: KairoRegistry): void;
-}
-
-declare class AddonRegistrationManager {
-    private readonly parser;
-    private readonly builder;
-    private readonly responder;
-    private constructor(parser: RegistrationRequestParser, builder: KairoRegistryBuilder, responder: RegistrationResponder);
-    resolveRegistry(message: string, kairoId: string, addonProperties: AddonProperties): KairoRegistry | undefined;
-    handleRegistrationResult(message: string): void;
-    dispose(): void;
 }
 
 declare class KairoInitializer implements Disposable {

--- a/lib/index.js
+++ b/lib/index.js
@@ -28,446 +28,6 @@ var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__ge
   mod
 ));
 
-// node_modules/.pnpm/dequal@2.0.3/node_modules/dequal/dist/index.js
-var require_dist = __commonJS({
-  "node_modules/.pnpm/dequal@2.0.3/node_modules/dequal/dist/index.js"(exports) {
-    "use strict";
-    var has = Object.prototype.hasOwnProperty;
-    function find(iter, tar, key) {
-      for (key of iter.keys()) {
-        if (dequal(key, tar)) return key;
-      }
-    }
-    function dequal(foo, bar) {
-      var ctor, len, tmp;
-      if (foo === bar) return true;
-      if (foo && bar && (ctor = foo.constructor) === bar.constructor) {
-        if (ctor === Date) return foo.getTime() === bar.getTime();
-        if (ctor === RegExp) return foo.toString() === bar.toString();
-        if (ctor === Array) {
-          if ((len = foo.length) === bar.length) {
-            while (len-- && dequal(foo[len], bar[len])) ;
-          }
-          return len === -1;
-        }
-        if (ctor === Set) {
-          if (foo.size !== bar.size) {
-            return false;
-          }
-          for (len of foo) {
-            tmp = len;
-            if (tmp && typeof tmp === "object") {
-              tmp = find(bar, tmp);
-              if (!tmp) return false;
-            }
-            if (!bar.has(tmp)) return false;
-          }
-          return true;
-        }
-        if (ctor === Map) {
-          if (foo.size !== bar.size) {
-            return false;
-          }
-          for (len of foo) {
-            tmp = len[0];
-            if (tmp && typeof tmp === "object") {
-              tmp = find(bar, tmp);
-              if (!tmp) return false;
-            }
-            if (!dequal(len[1], bar.get(tmp))) {
-              return false;
-            }
-          }
-          return true;
-        }
-        if (ctor === ArrayBuffer) {
-          foo = new Uint8Array(foo);
-          bar = new Uint8Array(bar);
-        } else if (ctor === DataView) {
-          if ((len = foo.byteLength) === bar.byteLength) {
-            while (len-- && foo.getInt8(len) === bar.getInt8(len)) ;
-          }
-          return len === -1;
-        }
-        if (ArrayBuffer.isView(foo)) {
-          if ((len = foo.byteLength) === bar.byteLength) {
-            while (len-- && foo[len] === bar[len]) ;
-          }
-          return len === -1;
-        }
-        if (!ctor || typeof foo === "object") {
-          len = 0;
-          for (ctor in foo) {
-            if (has.call(foo, ctor) && ++len && !has.call(bar, ctor)) return false;
-            if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor])) return false;
-          }
-          return Object.keys(bar).length === len;
-        }
-      }
-      return foo !== foo && bar !== bar;
-    }
-    exports.dequal = dequal;
-  }
-});
-
-// node_modules/.pnpm/json-schema-ref-resolver@3.0.0/node_modules/json-schema-ref-resolver/index.js
-var require_json_schema_ref_resolver = __commonJS({
-  "node_modules/.pnpm/json-schema-ref-resolver@3.0.0/node_modules/json-schema-ref-resolver/index.js"(exports, module) {
-    "use strict";
-    var { dequal: deepEqual } = require_dist();
-    var jsonSchemaRefSymbol = /* @__PURE__ */ Symbol.for("json-schema-ref");
-    var RefResolver = class {
-      #schemas;
-      #derefSchemas;
-      #insertRefSymbol;
-      #allowEqualDuplicates;
-      #cloneSchemaWithoutRefs;
-      constructor(opts = {}) {
-        this.#schemas = {};
-        this.#derefSchemas = {};
-        this.#insertRefSymbol = opts.insertRefSymbol ?? false;
-        this.#allowEqualDuplicates = opts.allowEqualDuplicates ?? true;
-        this.#cloneSchemaWithoutRefs = opts.cloneSchemaWithoutRefs ?? false;
-      }
-      addSchema(schema, rootSchemaId, isRootSchema = true) {
-        if (isRootSchema) {
-          if (schema.$id !== void 0 && schema.$id.charAt(0) !== "#") {
-            rootSchemaId = schema.$id;
-          } else {
-            this.#insertSchemaBySchemaId(schema, rootSchemaId);
-          }
-        }
-        const schemaId = schema.$id;
-        if (schemaId !== void 0 && typeof schemaId === "string") {
-          if (schemaId.charAt(0) === "#") {
-            this.#insertSchemaByAnchor(schema, rootSchemaId, schemaId);
-          } else {
-            this.#insertSchemaBySchemaId(schema, schemaId);
-            rootSchemaId = schemaId;
-          }
-        }
-        const ref = schema.$ref;
-        if (ref !== void 0 && typeof ref === "string") {
-          const { refSchemaId, refJsonPointer } = this.#parseSchemaRef(ref, rootSchemaId);
-          this.#schemas[rootSchemaId].refs.push({
-            schemaId: refSchemaId,
-            jsonPointer: refJsonPointer
-          });
-        }
-        for (const key in schema) {
-          if (typeof schema[key] === "object" && schema[key] !== null) {
-            this.addSchema(schema[key], rootSchemaId, false);
-          }
-        }
-      }
-      getSchema(schemaId, jsonPointer = "#") {
-        const schema = this.#schemas[schemaId];
-        if (schema === void 0) {
-          throw new Error(
-            `Cannot resolve ref "${schemaId}${jsonPointer}". Schema with id "${schemaId}" is not found.`
-          );
-        }
-        if (schema.anchors[jsonPointer] !== void 0) {
-          return schema.anchors[jsonPointer];
-        }
-        return getDataByJSONPointer(schema.schema, jsonPointer);
-      }
-      hasSchema(schemaId) {
-        return this.#schemas[schemaId] !== void 0;
-      }
-      getSchemaRefs(schemaId) {
-        const schema = this.#schemas[schemaId];
-        if (schema === void 0) {
-          throw new Error(`Schema with id "${schemaId}" is not found.`);
-        }
-        return schema.refs;
-      }
-      getSchemaDependencies(schemaId, dependencies = {}) {
-        const schema = this.#schemas[schemaId];
-        for (const ref of schema.refs) {
-          const dependencySchemaId = ref.schemaId;
-          if (dependencySchemaId === schemaId || dependencies[dependencySchemaId] !== void 0) continue;
-          dependencies[dependencySchemaId] = this.getSchema(dependencySchemaId);
-          this.getSchemaDependencies(dependencySchemaId, dependencies);
-        }
-        return dependencies;
-      }
-      derefSchema(schemaId) {
-        if (this.#derefSchemas[schemaId] !== void 0) return;
-        const schema = this.#schemas[schemaId];
-        if (schema === void 0) {
-          throw new Error(`Schema with id "${schemaId}" is not found.`);
-        }
-        if (!this.#cloneSchemaWithoutRefs && schema.refs.length === 0) {
-          this.#derefSchemas[schemaId] = {
-            schema: schema.schema,
-            anchors: schema.anchors
-          };
-        }
-        const refs = [];
-        this.#addDerefSchema(schema.schema, schemaId, true, refs);
-        const dependencies = this.getSchemaDependencies(schemaId);
-        for (const schemaId2 in dependencies) {
-          const schema2 = dependencies[schemaId2];
-          this.#addDerefSchema(schema2, schemaId2, true, refs);
-        }
-        for (const ref of refs) {
-          const {
-            refSchemaId,
-            refJsonPointer
-          } = this.#parseSchemaRef(ref.ref, ref.sourceSchemaId);
-          const targetSchema = this.getDerefSchema(refSchemaId, refJsonPointer);
-          if (targetSchema === null) {
-            throw new Error(
-              `Cannot resolve ref "${ref.ref}". Ref "${refJsonPointer}" is not found in schema "${refSchemaId}".`
-            );
-          }
-          ref.targetSchema = targetSchema;
-          ref.targetSchemaId = refSchemaId;
-        }
-        for (const ref of refs) {
-          this.#resolveRef(ref, refs);
-        }
-      }
-      getDerefSchema(schemaId, jsonPointer = "#") {
-        let derefSchema = this.#derefSchemas[schemaId];
-        if (derefSchema === void 0) {
-          this.derefSchema(schemaId);
-          derefSchema = this.#derefSchemas[schemaId];
-        }
-        if (derefSchema.anchors[jsonPointer] !== void 0) {
-          return derefSchema.anchors[jsonPointer];
-        }
-        return getDataByJSONPointer(derefSchema.schema, jsonPointer);
-      }
-      #parseSchemaRef(ref, schemaId) {
-        const sharpIndex = ref.indexOf("#");
-        if (sharpIndex === -1) {
-          return { refSchemaId: ref, refJsonPointer: "#" };
-        }
-        if (sharpIndex === 0) {
-          return { refSchemaId: schemaId, refJsonPointer: ref };
-        }
-        return {
-          refSchemaId: ref.slice(0, sharpIndex),
-          refJsonPointer: ref.slice(sharpIndex)
-        };
-      }
-      #addDerefSchema(schema, rootSchemaId, isRootSchema, refs = []) {
-        const derefSchema = Array.isArray(schema) ? [...schema] : { ...schema };
-        if (isRootSchema) {
-          if (schema.$id !== void 0 && schema.$id.charAt(0) !== "#") {
-            rootSchemaId = schema.$id;
-          } else {
-            this.#insertDerefSchemaBySchemaId(derefSchema, rootSchemaId);
-          }
-        }
-        const schemaId = derefSchema.$id;
-        if (schemaId !== void 0 && typeof schemaId === "string") {
-          if (schemaId.charAt(0) === "#") {
-            this.#insertDerefSchemaByAnchor(derefSchema, rootSchemaId, schemaId);
-          } else {
-            this.#insertDerefSchemaBySchemaId(derefSchema, schemaId);
-            rootSchemaId = schemaId;
-          }
-        }
-        if (derefSchema.$ref !== void 0) {
-          refs.push({
-            ref: derefSchema.$ref,
-            sourceSchemaId: rootSchemaId,
-            sourceSchema: derefSchema
-          });
-        }
-        for (const key in derefSchema) {
-          const value = derefSchema[key];
-          if (typeof value === "object" && value !== null) {
-            derefSchema[key] = this.#addDerefSchema(value, rootSchemaId, false, refs);
-          }
-        }
-        return derefSchema;
-      }
-      #resolveRef(ref, refs) {
-        const { sourceSchema, targetSchema } = ref;
-        if (!sourceSchema.$ref) return;
-        if (this.#insertRefSymbol) {
-          sourceSchema[jsonSchemaRefSymbol] = sourceSchema.$ref;
-        }
-        delete sourceSchema.$ref;
-        if (targetSchema.$ref) {
-          const targetSchemaRef = refs.find((ref2) => ref2.sourceSchema === targetSchema);
-          this.#resolveRef(targetSchemaRef, refs);
-        }
-        for (const key in targetSchema) {
-          if (key === "$id") continue;
-          if (sourceSchema[key] !== void 0) {
-            if (deepEqual(sourceSchema[key], targetSchema[key])) continue;
-            throw new Error(
-              `Cannot resolve ref "${ref.ref}". Property "${key}" already exists in schema "${ref.sourceSchemaId}".`
-            );
-          }
-          sourceSchema[key] = targetSchema[key];
-        }
-        ref.isResolved = true;
-      }
-      #insertSchemaBySchemaId(schema, schemaId) {
-        const foundSchema = this.#schemas[schemaId];
-        if (foundSchema !== void 0) {
-          if (this.#allowEqualDuplicates && deepEqual(schema, foundSchema.schema)) return;
-          throw new Error(`There is already another schema with id "${schemaId}".`);
-        }
-        this.#schemas[schemaId] = { schema, anchors: {}, refs: [] };
-      }
-      #insertSchemaByAnchor(schema, schemaId, anchor) {
-        const { anchors } = this.#schemas[schemaId];
-        if (anchors[anchor] !== void 0) {
-          throw new Error(`There is already another anchor "${anchor}" in schema "${schemaId}".`);
-        }
-        anchors[anchor] = schema;
-      }
-      #insertDerefSchemaBySchemaId(schema, schemaId) {
-        const foundSchema = this.#derefSchemas[schemaId];
-        if (foundSchema !== void 0) return;
-        this.#derefSchemas[schemaId] = { schema, anchors: {} };
-      }
-      #insertDerefSchemaByAnchor(schema, schemaId, anchor) {
-        const { anchors } = this.#derefSchemas[schemaId];
-        anchors[anchor] = schema;
-      }
-    };
-    function getDataByJSONPointer(data, jsonPointer) {
-      const parts = jsonPointer.split("/");
-      let current = data;
-      for (const part of parts) {
-        if (part === "" || part === "#") continue;
-        if (typeof current !== "object" || current === null) {
-          return null;
-        }
-        current = current[part];
-      }
-      return current ?? null;
-    }
-    module.exports = { RefResolver };
-  }
-});
-
-// node_modules/.pnpm/fast-json-stringify@6.3.0/node_modules/fast-json-stringify/lib/serializer.js
-var require_serializer = __commonJS({
-  "node_modules/.pnpm/fast-json-stringify@6.3.0/node_modules/fast-json-stringify/lib/serializer.js"(exports, module) {
-    "use strict";
-    var STR_ESCAPE = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]/;
-    module.exports = class Serializer {
-      constructor(options) {
-        switch (options && options.rounding) {
-          case "floor":
-            this.parseInteger = Math.floor;
-            break;
-          case "ceil":
-            this.parseInteger = Math.ceil;
-            break;
-          case "round":
-            this.parseInteger = Math.round;
-            break;
-          case "trunc":
-          default:
-            this.parseInteger = Math.trunc;
-            break;
-        }
-        this._options = options;
-      }
-      asInteger(i) {
-        if (Number.isInteger(i)) {
-          return "" + i;
-        } else if (typeof i === "bigint") {
-          return i.toString();
-        }
-        const integer = this.parseInteger(i);
-        if (integer === Infinity || integer === -Infinity || integer !== integer) {
-          throw new Error(`The value "${i}" cannot be converted to an integer.`);
-        }
-        return "" + integer;
-      }
-      asNumber(i) {
-        const num = Number(i);
-        if (num !== num) {
-          throw new Error(`The value "${i}" cannot be converted to a number.`);
-        } else if (num === Infinity || num === -Infinity) {
-          return "null";
-        } else {
-          return "" + num;
-        }
-      }
-      asBoolean(bool) {
-        return bool && "true" || "false";
-      }
-      asDateTime(date) {
-        if (date === null) return '""';
-        if (date instanceof Date) {
-          return '"' + date.toISOString() + '"';
-        }
-        if (typeof date === "string") {
-          return '"' + date + '"';
-        }
-        throw new Error(`The value "${date}" cannot be converted to a date-time.`);
-      }
-      asDate(date) {
-        if (date === null) return '""';
-        if (date instanceof Date) {
-          return '"' + new Date(date.getTime() - date.getTimezoneOffset() * 6e4).toISOString().slice(0, 10) + '"';
-        }
-        if (typeof date === "string") {
-          return '"' + date + '"';
-        }
-        throw new Error(`The value "${date}" cannot be converted to a date.`);
-      }
-      asTime(date) {
-        if (date === null) return '""';
-        if (date instanceof Date) {
-          return '"' + new Date(date.getTime() - date.getTimezoneOffset() * 6e4).toISOString().slice(11, 19) + '"';
-        }
-        if (typeof date === "string") {
-          return '"' + date + '"';
-        }
-        throw new Error(`The value "${date}" cannot be converted to a time.`);
-      }
-      asString(str) {
-        const len = str.length;
-        if (len === 0) {
-          return '""';
-        } else if (len < 42) {
-          let result = "";
-          let last = -1;
-          let point = 255;
-          for (let i = 0; i < len; i++) {
-            point = str.charCodeAt(i);
-            if (point === 34 || // '"'
-            point === 92) {
-              last === -1 && (last = 0);
-              result += str.slice(last, i) + "\\";
-              last = i;
-            } else if (point < 32 || point >= 55296 && point <= 57343) {
-              return JSON.stringify(str);
-            }
-          }
-          return last === -1 && '"' + str + '"' || '"' + result + str.slice(last) + '"';
-        } else if (len < 5e3 && STR_ESCAPE.test(str) === false) {
-          return '"' + str + '"';
-        } else {
-          return JSON.stringify(str);
-        }
-      }
-      asUnsafeString(str) {
-        return '"' + str + '"';
-      }
-      getState() {
-        return this._options;
-      }
-      static restoreFromState(state) {
-        return new Serializer(state);
-      }
-    };
-  }
-});
-
 // node_modules/.pnpm/ajv@8.18.0/node_modules/ajv/dist/compile/codegen/code.js
 var require_code = __commonJS({
   "node_modules/.pnpm/ajv@8.18.0/node_modules/ajv/dist/compile/codegen/code.js"(exports) {
@@ -6920,6 +6480,446 @@ var require_ajv = __commonJS({
   }
 });
 
+// node_modules/.pnpm/dequal@2.0.3/node_modules/dequal/dist/index.js
+var require_dist = __commonJS({
+  "node_modules/.pnpm/dequal@2.0.3/node_modules/dequal/dist/index.js"(exports) {
+    "use strict";
+    var has = Object.prototype.hasOwnProperty;
+    function find(iter, tar, key) {
+      for (key of iter.keys()) {
+        if (dequal(key, tar)) return key;
+      }
+    }
+    function dequal(foo, bar) {
+      var ctor, len, tmp;
+      if (foo === bar) return true;
+      if (foo && bar && (ctor = foo.constructor) === bar.constructor) {
+        if (ctor === Date) return foo.getTime() === bar.getTime();
+        if (ctor === RegExp) return foo.toString() === bar.toString();
+        if (ctor === Array) {
+          if ((len = foo.length) === bar.length) {
+            while (len-- && dequal(foo[len], bar[len])) ;
+          }
+          return len === -1;
+        }
+        if (ctor === Set) {
+          if (foo.size !== bar.size) {
+            return false;
+          }
+          for (len of foo) {
+            tmp = len;
+            if (tmp && typeof tmp === "object") {
+              tmp = find(bar, tmp);
+              if (!tmp) return false;
+            }
+            if (!bar.has(tmp)) return false;
+          }
+          return true;
+        }
+        if (ctor === Map) {
+          if (foo.size !== bar.size) {
+            return false;
+          }
+          for (len of foo) {
+            tmp = len[0];
+            if (tmp && typeof tmp === "object") {
+              tmp = find(bar, tmp);
+              if (!tmp) return false;
+            }
+            if (!dequal(len[1], bar.get(tmp))) {
+              return false;
+            }
+          }
+          return true;
+        }
+        if (ctor === ArrayBuffer) {
+          foo = new Uint8Array(foo);
+          bar = new Uint8Array(bar);
+        } else if (ctor === DataView) {
+          if ((len = foo.byteLength) === bar.byteLength) {
+            while (len-- && foo.getInt8(len) === bar.getInt8(len)) ;
+          }
+          return len === -1;
+        }
+        if (ArrayBuffer.isView(foo)) {
+          if ((len = foo.byteLength) === bar.byteLength) {
+            while (len-- && foo[len] === bar[len]) ;
+          }
+          return len === -1;
+        }
+        if (!ctor || typeof foo === "object") {
+          len = 0;
+          for (ctor in foo) {
+            if (has.call(foo, ctor) && ++len && !has.call(bar, ctor)) return false;
+            if (!(ctor in bar) || !dequal(foo[ctor], bar[ctor])) return false;
+          }
+          return Object.keys(bar).length === len;
+        }
+      }
+      return foo !== foo && bar !== bar;
+    }
+    exports.dequal = dequal;
+  }
+});
+
+// node_modules/.pnpm/json-schema-ref-resolver@3.0.0/node_modules/json-schema-ref-resolver/index.js
+var require_json_schema_ref_resolver = __commonJS({
+  "node_modules/.pnpm/json-schema-ref-resolver@3.0.0/node_modules/json-schema-ref-resolver/index.js"(exports, module) {
+    "use strict";
+    var { dequal: deepEqual } = require_dist();
+    var jsonSchemaRefSymbol = /* @__PURE__ */ Symbol.for("json-schema-ref");
+    var RefResolver = class {
+      #schemas;
+      #derefSchemas;
+      #insertRefSymbol;
+      #allowEqualDuplicates;
+      #cloneSchemaWithoutRefs;
+      constructor(opts = {}) {
+        this.#schemas = {};
+        this.#derefSchemas = {};
+        this.#insertRefSymbol = opts.insertRefSymbol ?? false;
+        this.#allowEqualDuplicates = opts.allowEqualDuplicates ?? true;
+        this.#cloneSchemaWithoutRefs = opts.cloneSchemaWithoutRefs ?? false;
+      }
+      addSchema(schema, rootSchemaId, isRootSchema = true) {
+        if (isRootSchema) {
+          if (schema.$id !== void 0 && schema.$id.charAt(0) !== "#") {
+            rootSchemaId = schema.$id;
+          } else {
+            this.#insertSchemaBySchemaId(schema, rootSchemaId);
+          }
+        }
+        const schemaId = schema.$id;
+        if (schemaId !== void 0 && typeof schemaId === "string") {
+          if (schemaId.charAt(0) === "#") {
+            this.#insertSchemaByAnchor(schema, rootSchemaId, schemaId);
+          } else {
+            this.#insertSchemaBySchemaId(schema, schemaId);
+            rootSchemaId = schemaId;
+          }
+        }
+        const ref = schema.$ref;
+        if (ref !== void 0 && typeof ref === "string") {
+          const { refSchemaId, refJsonPointer } = this.#parseSchemaRef(ref, rootSchemaId);
+          this.#schemas[rootSchemaId].refs.push({
+            schemaId: refSchemaId,
+            jsonPointer: refJsonPointer
+          });
+        }
+        for (const key in schema) {
+          if (typeof schema[key] === "object" && schema[key] !== null) {
+            this.addSchema(schema[key], rootSchemaId, false);
+          }
+        }
+      }
+      getSchema(schemaId, jsonPointer = "#") {
+        const schema = this.#schemas[schemaId];
+        if (schema === void 0) {
+          throw new Error(
+            `Cannot resolve ref "${schemaId}${jsonPointer}". Schema with id "${schemaId}" is not found.`
+          );
+        }
+        if (schema.anchors[jsonPointer] !== void 0) {
+          return schema.anchors[jsonPointer];
+        }
+        return getDataByJSONPointer(schema.schema, jsonPointer);
+      }
+      hasSchema(schemaId) {
+        return this.#schemas[schemaId] !== void 0;
+      }
+      getSchemaRefs(schemaId) {
+        const schema = this.#schemas[schemaId];
+        if (schema === void 0) {
+          throw new Error(`Schema with id "${schemaId}" is not found.`);
+        }
+        return schema.refs;
+      }
+      getSchemaDependencies(schemaId, dependencies = {}) {
+        const schema = this.#schemas[schemaId];
+        for (const ref of schema.refs) {
+          const dependencySchemaId = ref.schemaId;
+          if (dependencySchemaId === schemaId || dependencies[dependencySchemaId] !== void 0) continue;
+          dependencies[dependencySchemaId] = this.getSchema(dependencySchemaId);
+          this.getSchemaDependencies(dependencySchemaId, dependencies);
+        }
+        return dependencies;
+      }
+      derefSchema(schemaId) {
+        if (this.#derefSchemas[schemaId] !== void 0) return;
+        const schema = this.#schemas[schemaId];
+        if (schema === void 0) {
+          throw new Error(`Schema with id "${schemaId}" is not found.`);
+        }
+        if (!this.#cloneSchemaWithoutRefs && schema.refs.length === 0) {
+          this.#derefSchemas[schemaId] = {
+            schema: schema.schema,
+            anchors: schema.anchors
+          };
+        }
+        const refs = [];
+        this.#addDerefSchema(schema.schema, schemaId, true, refs);
+        const dependencies = this.getSchemaDependencies(schemaId);
+        for (const schemaId2 in dependencies) {
+          const schema2 = dependencies[schemaId2];
+          this.#addDerefSchema(schema2, schemaId2, true, refs);
+        }
+        for (const ref of refs) {
+          const {
+            refSchemaId,
+            refJsonPointer
+          } = this.#parseSchemaRef(ref.ref, ref.sourceSchemaId);
+          const targetSchema = this.getDerefSchema(refSchemaId, refJsonPointer);
+          if (targetSchema === null) {
+            throw new Error(
+              `Cannot resolve ref "${ref.ref}". Ref "${refJsonPointer}" is not found in schema "${refSchemaId}".`
+            );
+          }
+          ref.targetSchema = targetSchema;
+          ref.targetSchemaId = refSchemaId;
+        }
+        for (const ref of refs) {
+          this.#resolveRef(ref, refs);
+        }
+      }
+      getDerefSchema(schemaId, jsonPointer = "#") {
+        let derefSchema = this.#derefSchemas[schemaId];
+        if (derefSchema === void 0) {
+          this.derefSchema(schemaId);
+          derefSchema = this.#derefSchemas[schemaId];
+        }
+        if (derefSchema.anchors[jsonPointer] !== void 0) {
+          return derefSchema.anchors[jsonPointer];
+        }
+        return getDataByJSONPointer(derefSchema.schema, jsonPointer);
+      }
+      #parseSchemaRef(ref, schemaId) {
+        const sharpIndex = ref.indexOf("#");
+        if (sharpIndex === -1) {
+          return { refSchemaId: ref, refJsonPointer: "#" };
+        }
+        if (sharpIndex === 0) {
+          return { refSchemaId: schemaId, refJsonPointer: ref };
+        }
+        return {
+          refSchemaId: ref.slice(0, sharpIndex),
+          refJsonPointer: ref.slice(sharpIndex)
+        };
+      }
+      #addDerefSchema(schema, rootSchemaId, isRootSchema, refs = []) {
+        const derefSchema = Array.isArray(schema) ? [...schema] : { ...schema };
+        if (isRootSchema) {
+          if (schema.$id !== void 0 && schema.$id.charAt(0) !== "#") {
+            rootSchemaId = schema.$id;
+          } else {
+            this.#insertDerefSchemaBySchemaId(derefSchema, rootSchemaId);
+          }
+        }
+        const schemaId = derefSchema.$id;
+        if (schemaId !== void 0 && typeof schemaId === "string") {
+          if (schemaId.charAt(0) === "#") {
+            this.#insertDerefSchemaByAnchor(derefSchema, rootSchemaId, schemaId);
+          } else {
+            this.#insertDerefSchemaBySchemaId(derefSchema, schemaId);
+            rootSchemaId = schemaId;
+          }
+        }
+        if (derefSchema.$ref !== void 0) {
+          refs.push({
+            ref: derefSchema.$ref,
+            sourceSchemaId: rootSchemaId,
+            sourceSchema: derefSchema
+          });
+        }
+        for (const key in derefSchema) {
+          const value = derefSchema[key];
+          if (typeof value === "object" && value !== null) {
+            derefSchema[key] = this.#addDerefSchema(value, rootSchemaId, false, refs);
+          }
+        }
+        return derefSchema;
+      }
+      #resolveRef(ref, refs) {
+        const { sourceSchema, targetSchema } = ref;
+        if (!sourceSchema.$ref) return;
+        if (this.#insertRefSymbol) {
+          sourceSchema[jsonSchemaRefSymbol] = sourceSchema.$ref;
+        }
+        delete sourceSchema.$ref;
+        if (targetSchema.$ref) {
+          const targetSchemaRef = refs.find((ref2) => ref2.sourceSchema === targetSchema);
+          this.#resolveRef(targetSchemaRef, refs);
+        }
+        for (const key in targetSchema) {
+          if (key === "$id") continue;
+          if (sourceSchema[key] !== void 0) {
+            if (deepEqual(sourceSchema[key], targetSchema[key])) continue;
+            throw new Error(
+              `Cannot resolve ref "${ref.ref}". Property "${key}" already exists in schema "${ref.sourceSchemaId}".`
+            );
+          }
+          sourceSchema[key] = targetSchema[key];
+        }
+        ref.isResolved = true;
+      }
+      #insertSchemaBySchemaId(schema, schemaId) {
+        const foundSchema = this.#schemas[schemaId];
+        if (foundSchema !== void 0) {
+          if (this.#allowEqualDuplicates && deepEqual(schema, foundSchema.schema)) return;
+          throw new Error(`There is already another schema with id "${schemaId}".`);
+        }
+        this.#schemas[schemaId] = { schema, anchors: {}, refs: [] };
+      }
+      #insertSchemaByAnchor(schema, schemaId, anchor) {
+        const { anchors } = this.#schemas[schemaId];
+        if (anchors[anchor] !== void 0) {
+          throw new Error(`There is already another anchor "${anchor}" in schema "${schemaId}".`);
+        }
+        anchors[anchor] = schema;
+      }
+      #insertDerefSchemaBySchemaId(schema, schemaId) {
+        const foundSchema = this.#derefSchemas[schemaId];
+        if (foundSchema !== void 0) return;
+        this.#derefSchemas[schemaId] = { schema, anchors: {} };
+      }
+      #insertDerefSchemaByAnchor(schema, schemaId, anchor) {
+        const { anchors } = this.#derefSchemas[schemaId];
+        anchors[anchor] = schema;
+      }
+    };
+    function getDataByJSONPointer(data, jsonPointer) {
+      const parts = jsonPointer.split("/");
+      let current = data;
+      for (const part of parts) {
+        if (part === "" || part === "#") continue;
+        if (typeof current !== "object" || current === null) {
+          return null;
+        }
+        current = current[part];
+      }
+      return current ?? null;
+    }
+    module.exports = { RefResolver };
+  }
+});
+
+// node_modules/.pnpm/fast-json-stringify@6.3.0/node_modules/fast-json-stringify/lib/serializer.js
+var require_serializer = __commonJS({
+  "node_modules/.pnpm/fast-json-stringify@6.3.0/node_modules/fast-json-stringify/lib/serializer.js"(exports, module) {
+    "use strict";
+    var STR_ESCAPE = /[\u0000-\u001f\u0022\u005c\ud800-\udfff]/;
+    module.exports = class Serializer {
+      constructor(options) {
+        switch (options && options.rounding) {
+          case "floor":
+            this.parseInteger = Math.floor;
+            break;
+          case "ceil":
+            this.parseInteger = Math.ceil;
+            break;
+          case "round":
+            this.parseInteger = Math.round;
+            break;
+          case "trunc":
+          default:
+            this.parseInteger = Math.trunc;
+            break;
+        }
+        this._options = options;
+      }
+      asInteger(i) {
+        if (Number.isInteger(i)) {
+          return "" + i;
+        } else if (typeof i === "bigint") {
+          return i.toString();
+        }
+        const integer = this.parseInteger(i);
+        if (integer === Infinity || integer === -Infinity || integer !== integer) {
+          throw new Error(`The value "${i}" cannot be converted to an integer.`);
+        }
+        return "" + integer;
+      }
+      asNumber(i) {
+        const num = Number(i);
+        if (num !== num) {
+          throw new Error(`The value "${i}" cannot be converted to a number.`);
+        } else if (num === Infinity || num === -Infinity) {
+          return "null";
+        } else {
+          return "" + num;
+        }
+      }
+      asBoolean(bool) {
+        return bool && "true" || "false";
+      }
+      asDateTime(date) {
+        if (date === null) return '""';
+        if (date instanceof Date) {
+          return '"' + date.toISOString() + '"';
+        }
+        if (typeof date === "string") {
+          return '"' + date + '"';
+        }
+        throw new Error(`The value "${date}" cannot be converted to a date-time.`);
+      }
+      asDate(date) {
+        if (date === null) return '""';
+        if (date instanceof Date) {
+          return '"' + new Date(date.getTime() - date.getTimezoneOffset() * 6e4).toISOString().slice(0, 10) + '"';
+        }
+        if (typeof date === "string") {
+          return '"' + date + '"';
+        }
+        throw new Error(`The value "${date}" cannot be converted to a date.`);
+      }
+      asTime(date) {
+        if (date === null) return '""';
+        if (date instanceof Date) {
+          return '"' + new Date(date.getTime() - date.getTimezoneOffset() * 6e4).toISOString().slice(11, 19) + '"';
+        }
+        if (typeof date === "string") {
+          return '"' + date + '"';
+        }
+        throw new Error(`The value "${date}" cannot be converted to a time.`);
+      }
+      asString(str) {
+        const len = str.length;
+        if (len === 0) {
+          return '""';
+        } else if (len < 42) {
+          let result = "";
+          let last = -1;
+          let point = 255;
+          for (let i = 0; i < len; i++) {
+            point = str.charCodeAt(i);
+            if (point === 34 || // '"'
+            point === 92) {
+              last === -1 && (last = 0);
+              result += str.slice(last, i) + "\\";
+              last = i;
+            } else if (point < 32 || point >= 55296 && point <= 57343) {
+              return JSON.stringify(str);
+            }
+          }
+          return last === -1 && '"' + str + '"' || '"' + result + str.slice(last) + '"';
+        } else if (len < 5e3 && STR_ESCAPE.test(str) === false) {
+          return '"' + str + '"';
+        } else {
+          return JSON.stringify(str);
+        }
+      }
+      asUnsafeString(str) {
+        return '"' + str + '"';
+      }
+      getState() {
+        return this._options;
+      }
+      static restoreFromState(state) {
+        return new Serializer(state);
+      }
+    };
+  }
+});
+
 // node_modules/.pnpm/ajv-formats@3.0.1_ajv@8.18.0/node_modules/ajv-formats/dist/formats.js
 var require_formats = __commonJS({
   "node_modules/.pnpm/ajv-formats@3.0.1_ajv@8.18.0/node_modules/ajv-formats/dist/formats.js"(exports) {
@@ -10247,11 +10247,6 @@ var ScoreboardIdRegistryFactory = class {
   }
 };
 
-// src/utils/toError.ts
-function toError(e) {
-  return e instanceof Error ? e : new Error(String(e));
-}
-
 // src/router/init/KairoInitEventId.ts
 var KairoInitEventId = /* @__PURE__ */ ((KairoInitEventId2) => {
   KairoInitEventId2["DiscoveryQuery"] = "kairo:discovery_query";
@@ -10262,22 +10257,127 @@ var KairoInitEventId = /* @__PURE__ */ ((KairoInitEventId2) => {
   return KairoInitEventId2;
 })(KairoInitEventId || {});
 
-// src/router/init/discovery/response/errors.ts
-var DiscoveryResponseError = class extends Error {
+// src/router/init/KairoInitializer.ts
+var KairoInitializer = class {
+  constructor(context, contextMutator, initListener, discoveryManager, discoveryResponder, registrationManager, registrationResponder) {
+    this.context = context;
+    this.contextMutator = contextMutator;
+    this.initListener = initListener;
+    this.discoveryManager = discoveryManager;
+    this.discoveryResponder = discoveryResponder;
+    this.registrationManager = registrationManager;
+    this.registrationResponder = registrationResponder;
+  }
+  subscription;
+  setup() {
+    this.initListener.setHandlers({
+      ["kairo:discovery_query" /* DiscoveryQuery */]: (msg) => {
+        const kairoId = this.discoveryManager.resolveKairoId(msg);
+        this.discoveryResponder.respond(kairoId);
+        this.contextMutator.setKairoId(kairoId);
+      },
+      ["kairo:registration_request" /* RegistrationRequest */]: (msg) => {
+        const registry = this.registrationManager.resolveRegistry(
+          msg,
+          this.context.kairoId,
+          this.context.addonProperties
+        );
+        if (!registry) return;
+        this.registrationResponder.respond(registry);
+        this.contextMutator.setKairoRegistry(registry);
+      }
+    });
+    this.subscription = this.initListener.setup();
+  }
+  dispose() {
+    this.subscription?.dispose();
+    this.subscription = void 0;
+    this.discoveryManager.dispose();
+    this.registrationManager.dispose();
+  }
+};
+
+// src/router/init/KairoInitListener.ts
+var KairoInitListener = class {
+  constructor(runtime2) {
+    this.runtime = runtime2;
+  }
+  handlers = {};
+  setHandlers(handlers) {
+    this.handlers = handlers;
+  }
+  setup() {
+    return this.runtime.subscribe(this.onEvent);
+  }
+  onEvent = (id, message) => {
+    if (!this.isKairoInitEventId(id)) return;
+    this.handlers[id]?.(message);
+  };
+  isKairoInitEventId(id) {
+    return Object.values(KairoInitEventId).includes(id);
+  }
+};
+
+// src/router/init/discovery/AddonDiscoveryManager.ts
+var AddonDiscoveryManager = class {
+  constructor(addonProperties, queryParser, idProvider) {
+    this.addonProperties = addonProperties;
+    this.queryParser = queryParser;
+    this.idProvider = idProvider;
+  }
+  resolveKairoId(message) {
+    const query = this.queryParser.parse(message);
+    return this.idProvider.provideId(this.addonProperties, query);
+  }
+  dispose() {
+  }
+};
+
+// src/utils/TimestampValidator.ts
+var TimestampValidator = class {
+  static isFuture(currentTick, timestamp) {
+    return timestamp > currentTick;
+  }
+  static isExpired(currentTick, timestamp, timeout) {
+    return currentTick - timestamp > timeout;
+  }
+  static isValid(currentTick, timestamp, timeout) {
+    return !this.isFuture(currentTick, timestamp) && !this.isExpired(currentTick, timestamp, timeout);
+  }
+};
+
+// src/utils/toError.ts
+function toError(e) {
+  return e instanceof Error ? e : new Error(String(e));
+}
+
+// src/router/init/discovery/query/errors.ts
+var DiscoveryQueryParseError = class extends Error {
   reason;
-  cause;
-  constructor(reason, options) {
+  constructor(reason, options = {}) {
     super(DEFAULT_MESSAGES[reason], { cause: options.cause });
-    this.name = "DiscoveryResponseError";
+    this.name = "DiscoveryQueryParseError";
     this.reason = reason;
   }
 };
 var DEFAULT_MESSAGES = {
-  ["StringifyFailed" /* StringifyFailed */]: "Failed to stringify discovery response."
+  ["InvalidJSON" /* InvalidJSON */]: "Failed to parse DiscoveryQuery JSON.",
+  ["InvalidStructure" /* InvalidStructure */]: "Invalid DiscoveryQuery structure.",
+  ["Timeout" /* Timeout */]: "DiscoveryQuery has timed out.",
+  ["FutureTimestamp" /* FutureTimestamp */]: "DiscoveryQuery timestamp is in the future."
 };
 
-// src/router/init/discovery/response/stringify.ts
-var import_fast_json_stringify = __toESM(require_fast_json_stringify(), 1);
+// src/utils/ajv-compile.ts
+var import_ajv = __toESM(require_ajv(), 1);
+var ajv = new import_ajv.default({
+  allErrors: true,
+  strict: true,
+  removeAdditional: false,
+  coerceTypes: false
+});
+function compile(schema) {
+  return ajv.compile(schema);
+}
 
 // node_modules/.pnpm/@sinclair+typebox@0.34.49/node_modules/@sinclair/typebox/build/esm/type/guard/value.mjs
 var value_exports = {};
@@ -12885,6 +12985,275 @@ __export(type_exports2, {
 // node_modules/.pnpm/@sinclair+typebox@0.34.49/node_modules/@sinclair/typebox/build/esm/type/type/index.mjs
 var Type = type_exports2;
 
+// src/router/init/discovery/query/schema.ts
+var DiscoveryQuerySchema = Type.Object(
+  {
+    timestamp: Type.Number(),
+    idNamespace: Type.String()
+  },
+  {
+    additionalProperties: false
+  }
+);
+
+// src/router/init/discovery/query/validate.ts
+var validateDiscoveryQuery = compile(DiscoveryQuerySchema);
+
+// src/router/init/discovery/DiscoveryQueryParser.ts
+var DiscoveryQueryParser = class {
+  constructor(runtime2) {
+    this.runtime = runtime2;
+  }
+  TIMEOUT_TICKS = 10;
+  parse(message) {
+    const parsed = this.parseJson(message);
+    if (!validateDiscoveryQuery(parsed)) {
+      throw new DiscoveryQueryParseError("InvalidStructure" /* InvalidStructure */, {
+        cause: toError(validateDiscoveryQuery.errors)
+      });
+    }
+    const query = parsed;
+    const currentTick = this.runtime.currentTick();
+    if (TimestampValidator.isExpired(currentTick, query.timestamp, this.TIMEOUT_TICKS)) {
+      throw new DiscoveryQueryParseError("Timeout" /* Timeout */);
+    }
+    if (TimestampValidator.isFuture(currentTick, query.timestamp)) {
+      throw new DiscoveryQueryParseError("FutureTimestamp" /* FutureTimestamp */);
+    }
+    return query;
+  }
+  parseJson(message) {
+    try {
+      return JSON.parse(message);
+    } catch {
+      throw new DiscoveryQueryParseError("InvalidJSON" /* InvalidJSON */);
+    }
+  }
+};
+
+// src/router/init/discovery/idProvider/errors.ts
+var ProvideKairoIdError = class extends Error {
+  reason;
+  constructor(reason, options = {}) {
+    super(DEFAULT_MESSAGES2[reason], { cause: options.cause });
+    this.name = "ProvideKairoIdError";
+    this.reason = reason;
+  }
+};
+var DEFAULT_MESSAGES2 = {
+  ["IdGenerationFailed" /* IdGenerationFailed */]: "Failed to generate a unique addon ID."
+};
+
+// src/router/init/discovery/KairoIdProvider.ts
+var KairoIdProvider = class {
+  constructor(idRegistryFactory2) {
+    this.idRegistryFactory = idRegistryFactory2;
+  }
+  CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?_-().";
+  PREFIX_LENGTH = 8;
+  ID_LENGTH = 16;
+  provideId(properties, query) {
+    const registry = this.idRegistryFactory.create(query.idNamespace);
+    const prefix = this.hash(properties.id);
+    let addonId;
+    let attempts = 0;
+    do {
+      addonId = `${prefix}-${this.generateId()}`;
+      attempts++;
+      if (attempts > 100) {
+        throw new ProvideKairoIdError("IdGenerationFailed" /* IdGenerationFailed */);
+      }
+    } while (registry.has(addonId));
+    registry.register(addonId);
+    return addonId;
+  }
+  generateId(length = this.ID_LENGTH) {
+    const chars = this.CHARSET;
+    let result = "";
+    for (let i = 0; i < length; i++) {
+      result += chars[Math.random() * chars.length | 0];
+    }
+    return result;
+  }
+  hash(input) {
+    let hash = 2166136261;
+    for (let i = 0; i < input.length; i++) {
+      hash ^= input.charCodeAt(i);
+      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
+    }
+    return (hash >>> 0).toString(36).padStart(this.PREFIX_LENGTH, "0");
+  }
+};
+
+// src/router/factories/AddonDiscoveryManagerFactory.ts
+var AddonDiscoveryManagerFactory = class {
+  constructor(runtime2, idRegistryFactory2) {
+    this.runtime = runtime2;
+    this.idRegistryFactory = idRegistryFactory2;
+  }
+  create(context) {
+    return new AddonDiscoveryManager(
+      context.addonProperties,
+      new DiscoveryQueryParser(this.runtime),
+      new KairoIdProvider(this.idRegistryFactory)
+    );
+  }
+};
+
+// src/router/init/errors.ts
+var KairoRouterInitError = class extends Error {
+  reason;
+  constructor(reason, options = {}) {
+    super(DEFAULT_MESSAGES3[reason], { cause: options.cause });
+    this.name = "KairoRouterInitError";
+    this.reason = reason;
+  }
+};
+var DEFAULT_MESSAGES3 = {
+  ["NotInitialized" /* NotInitialized */]: "Kairo router is not initialized. Call init() first.",
+  ["AlreadyInitialized" /* AlreadyInitialized */]: "Kairo router has already been initialized.",
+  ["RegistrationRejected" /* RegistrationRejected */]: "Addon registration was rejected.",
+  ["RegistrationRequestNotFound" /* RegistrationRequestNotFound */]: "Registration request not found."
+};
+
+// src/router/init/registration/AddonRegistrationManager.ts
+var AddonRegistrationManager = class {
+  constructor(parser, builder) {
+    this.parser = parser;
+    this.builder = builder;
+  }
+  resolveRegistry(message, kairoId, addonProperties) {
+    const request = this.parser.parse(message);
+    if (request.rejects.includes(kairoId)) {
+      throw new KairoRouterInitError("RegistrationRejected" /* RegistrationRejected */);
+    }
+    if (!request.approvals.includes(kairoId)) {
+      return;
+    }
+    const registry = this.builder.build(kairoId, addonProperties);
+    return registry;
+  }
+  dispose() {
+  }
+};
+
+// src/router/init/registration/KairoRegistryBuilder.ts
+var KairoRegistryBuilder = class {
+  build(kairoId, props) {
+    return {
+      kairoId,
+      addonId: props.id,
+      name: props.header.name,
+      description: props.header.description,
+      version: props.header.version,
+      metadata: {
+        authors: props.metadata?.authors ?? [],
+        url: props.metadata?.url,
+        license: props.metadata?.license
+      },
+      requiredAddons: props.requiredAddons ?? {},
+      tags: props.tags ?? []
+    };
+  }
+};
+
+// src/router/init/registration/request/errors.ts
+var RegistrationRequestParseError = class extends Error {
+  reason;
+  constructor(reason, options = {}) {
+    super(DEFAULT_MESSAGES4[reason], { cause: options.cause });
+    this.name = "RegistrationRequestParseError";
+    this.reason = reason;
+  }
+};
+var DEFAULT_MESSAGES4 = {
+  ["InvalidJSON" /* InvalidJSON */]: "Failed to parse RegistrationRequest JSON.",
+  ["InvalidStructure" /* InvalidStructure */]: "Invalid RegistrationRequest structure.",
+  ["Timeout" /* Timeout */]: "RegistrationRequest has timed out.",
+  ["FutureTimestamp" /* FutureTimestamp */]: "RegistrationRequest timestamp is in the future."
+};
+
+// src/router/init/registration/request/schema.ts
+var RegistrationRequestSchema = Type.Object(
+  {
+    approvals: Type.Array(Type.String()),
+    rejects: Type.Array(Type.String()),
+    timestamp: Type.Number()
+  },
+  {
+    additionalProperties: false
+  }
+);
+
+// src/router/init/registration/request/validate.ts
+var validateRegistrationRequest = compile(RegistrationRequestSchema);
+
+// src/router/init/registration/RegistrationRequestParser.ts
+var RegistrationRequestParser = class {
+  constructor(runtime2) {
+    this.runtime = runtime2;
+  }
+  TIMEOUT_TICKS = 10;
+  parse(message) {
+    const parsed = this.parseJson(message);
+    const currentTick = this.runtime.currentTick();
+    if (!validateRegistrationRequest(parsed)) {
+      throw new RegistrationRequestParseError(
+        "InvalidStructure" /* InvalidStructure */
+      );
+    }
+    const query = parsed;
+    if (TimestampValidator.isExpired(currentTick, query.timestamp, this.TIMEOUT_TICKS)) {
+      throw new RegistrationRequestParseError("Timeout" /* Timeout */);
+    }
+    if (TimestampValidator.isFuture(currentTick, query.timestamp)) {
+      throw new RegistrationRequestParseError(
+        "FutureTimestamp" /* FutureTimestamp */
+      );
+    }
+    return query;
+  }
+  parseJson(message) {
+    try {
+      return JSON.parse(message);
+    } catch {
+      throw new RegistrationRequestParseError(
+        "InvalidJSON" /* InvalidJSON */
+      );
+    }
+  }
+};
+
+// src/router/factories/AddonRegistrationManagerFactory.ts
+var AddonRegistrationManagerFactory = class {
+  constructor(runtime2) {
+    this.runtime = runtime2;
+  }
+  create() {
+    return new AddonRegistrationManager(
+      new RegistrationRequestParser(this.runtime),
+      new KairoRegistryBuilder()
+    );
+  }
+};
+
+// src/router/init/discovery/response/errors.ts
+var DiscoveryResponseError = class extends Error {
+  reason;
+  cause;
+  constructor(reason, options) {
+    super(DEFAULT_MESSAGES5[reason], { cause: options.cause });
+    this.name = "DiscoveryResponseError";
+    this.reason = reason;
+  }
+};
+var DEFAULT_MESSAGES5 = {
+  ["StringifyFailed" /* StringifyFailed */]: "Failed to stringify discovery response."
+};
+
+// src/router/init/discovery/response/stringify.ts
+var import_fast_json_stringify = __toESM(require_fast_json_stringify(), 1);
+
 // src/router/init/discovery/response/schema.ts
 var DiscoveryResponseSchema = Type.Object(
   {
@@ -12918,64 +13287,13 @@ var DiscoveryResponder = class {
   }
 };
 
-// src/router/init/KairoInitializer.ts
-var KairoInitializer = class {
-  constructor(context, contextMutator, initListener, discoveryManager, discoveryResponder, registrationManager, registrationResponder) {
-    this.context = context;
-    this.contextMutator = contextMutator;
-    this.initListener = initListener;
-    this.discoveryManager = discoveryManager;
-    this.discoveryResponder = discoveryResponder;
-    this.registrationManager = registrationManager;
-    this.registrationResponder = registrationResponder;
-  }
-  subscription;
-  setup() {
-    this.initListener.setHandlers({
-      ["kairo:discovery_query" /* DiscoveryQuery */]: (msg) => {
-        const kairoId = this.discoveryManager.resolveKairoId(msg);
-        this.discoveryResponder.respond(kairoId);
-        this.contextMutator.setKairoId(kairoId);
-      },
-      ["kairo:registration_request" /* RegistrationRequest */]: (msg) => {
-        const registry = this.registrationManager.resolveRegistry(
-          msg,
-          this.context.kairoId,
-          this.context.addonProperties
-        );
-        if (!registry) return;
-        this.registrationResponder.respond(registry);
-        this.contextMutator.setKairoRegistry(registry);
-      }
-    });
-    this.subscription = this.initListener.setup();
-  }
-  dispose() {
-    this.subscription?.dispose();
-    this.subscription = void 0;
-    this.discoveryManager.dispose();
-    this.registrationManager.dispose();
-  }
-};
-
-// src/router/init/KairoInitListener.ts
-var KairoInitListener = class {
+// src/router/factories/DiscoveryResponderFactory.ts
+var DiscoveryResponderFactory = class {
   constructor(runtime2) {
     this.runtime = runtime2;
   }
-  handlers = {};
-  setHandlers(handlers) {
-    this.handlers = handlers;
-  }
-  setup() {
-    return this.runtime.subscribe(this.onEvent);
-  }
-  onEvent = (id, message) => {
-    if (!this.isKairoInitEventId(id)) return;
-    this.handlers[id]?.(message);
-  };
-  isKairoInitEventId(id) {
-    return Object.values(KairoInitEventId).includes(id);
+  create() {
+    return new DiscoveryResponder(this.runtime);
   }
 };
 
@@ -12983,12 +13301,12 @@ var KairoInitListener = class {
 var RegistrationResponseError = class extends Error {
   reason;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES2[reason], { cause: options.cause });
+    super(DEFAULT_MESSAGES6[reason], { cause: options.cause });
     this.name = "RegistrationResponseError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES2 = {
+var DEFAULT_MESSAGES6 = {
   ["StringifyFailed" /* StringifyFailed */]: "Failed to stringify registration response."
 };
 
@@ -13061,323 +13379,13 @@ var RegistrationResponder = class {
   }
 };
 
-// src/router/init/discovery/AddonDiscoveryManager.ts
-var AddonDiscoveryManager = class {
-  constructor(addonProperties, queryParser, idProvider, responder) {
-    this.addonProperties = addonProperties;
-    this.queryParser = queryParser;
-    this.idProvider = idProvider;
-    this.responder = responder;
-  }
-  resolveKairoId(message) {
-    const query = this.queryParser.parse(message);
-    return this.idProvider.provideId(this.addonProperties, query);
-  }
-  handleRegistrationQuery(message) {
-    const query = this.queryParser.parse(message);
-    const kairoId = this.idProvider.provideId(this.addonProperties, query);
-    this.responder.respond(kairoId);
-    return kairoId;
-  }
-  dispose() {
-  }
-};
-
-// src/utils/TimestampValidator.ts
-var TimestampValidator = class {
-  static isFuture(currentTick, timestamp) {
-    return timestamp > currentTick;
-  }
-  static isExpired(currentTick, timestamp, timeout) {
-    return currentTick - timestamp > timeout;
-  }
-  static isValid(currentTick, timestamp, timeout) {
-    return !this.isFuture(currentTick, timestamp) && !this.isExpired(currentTick, timestamp, timeout);
-  }
-};
-
-// src/router/init/discovery/query/errors.ts
-var DiscoveryQueryParseError = class extends Error {
-  reason;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES3[reason], { cause: options.cause });
-    this.name = "DiscoveryQueryParseError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES3 = {
-  ["InvalidJSON" /* InvalidJSON */]: "Failed to parse DiscoveryQuery JSON.",
-  ["InvalidStructure" /* InvalidStructure */]: "Invalid DiscoveryQuery structure.",
-  ["Timeout" /* Timeout */]: "DiscoveryQuery has timed out.",
-  ["FutureTimestamp" /* FutureTimestamp */]: "DiscoveryQuery timestamp is in the future."
-};
-
-// src/utils/ajv-compile.ts
-var import_ajv = __toESM(require_ajv(), 1);
-var ajv = new import_ajv.default({
-  allErrors: true,
-  strict: true,
-  removeAdditional: false,
-  coerceTypes: false
-});
-function compile(schema) {
-  return ajv.compile(schema);
-}
-
-// src/router/init/discovery/query/schema.ts
-var DiscoveryQuerySchema = Type.Object(
-  {
-    timestamp: Type.Number(),
-    idNamespace: Type.String()
-  },
-  {
-    additionalProperties: false
-  }
-);
-
-// src/router/init/discovery/query/validate.ts
-var validateDiscoveryQuery = compile(DiscoveryQuerySchema);
-
-// src/router/init/discovery/DiscoveryQueryParser.ts
-var DiscoveryQueryParser = class {
-  constructor(runtime2) {
-    this.runtime = runtime2;
-  }
-  TIMEOUT_TICKS = 10;
-  parse(message) {
-    const parsed = this.parseJson(message);
-    if (!validateDiscoveryQuery(parsed)) {
-      throw new DiscoveryQueryParseError("InvalidStructure" /* InvalidStructure */, {
-        cause: toError(validateDiscoveryQuery.errors)
-      });
-    }
-    const query = parsed;
-    const currentTick = this.runtime.currentTick();
-    if (TimestampValidator.isExpired(currentTick, query.timestamp, this.TIMEOUT_TICKS)) {
-      throw new DiscoveryQueryParseError("Timeout" /* Timeout */);
-    }
-    if (TimestampValidator.isFuture(currentTick, query.timestamp)) {
-      throw new DiscoveryQueryParseError("FutureTimestamp" /* FutureTimestamp */);
-    }
-    return query;
-  }
-  parseJson(message) {
-    try {
-      return JSON.parse(message);
-    } catch {
-      throw new DiscoveryQueryParseError("InvalidJSON" /* InvalidJSON */);
-    }
-  }
-};
-
-// src/router/init/discovery/idProvider/errors.ts
-var ProvideKairoIdError = class extends Error {
-  reason;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES4[reason], { cause: options.cause });
-    this.name = "ProvideKairoIdError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES4 = {
-  ["IdGenerationFailed" /* IdGenerationFailed */]: "Failed to generate a unique addon ID."
-};
-
-// src/router/init/discovery/KairoIdProvider.ts
-var KairoIdProvider = class {
-  constructor(idRegistryFactory2) {
-    this.idRegistryFactory = idRegistryFactory2;
-  }
-  CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?_-().";
-  PREFIX_LENGTH = 8;
-  ID_LENGTH = 16;
-  provideId(properties, query) {
-    const registry = this.idRegistryFactory.create(query.idNamespace);
-    const prefix = this.hash(properties.id);
-    let addonId;
-    let attempts = 0;
-    do {
-      addonId = `${prefix}-${this.generateId()}`;
-      attempts++;
-      if (attempts > 100) {
-        throw new ProvideKairoIdError("IdGenerationFailed" /* IdGenerationFailed */);
-      }
-    } while (registry.has(addonId));
-    registry.register(addonId);
-    return addonId;
-  }
-  generateId(length = this.ID_LENGTH) {
-    const chars = this.CHARSET;
-    let result = "";
-    for (let i = 0; i < length; i++) {
-      result += chars[Math.random() * chars.length | 0];
-    }
-    return result;
-  }
-  hash(input) {
-    let hash = 2166136261;
-    for (let i = 0; i < input.length; i++) {
-      hash ^= input.charCodeAt(i);
-      hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
-    }
-    return (hash >>> 0).toString(36).padStart(this.PREFIX_LENGTH, "0");
-  }
-};
-
-// src/router/factories/AddonDiscoveryManagerFactory.ts
-var AddonDiscoveryManagerFactory = class {
-  constructor(runtime2, idRegistryFactory2) {
-    this.runtime = runtime2;
-    this.idRegistryFactory = idRegistryFactory2;
-  }
-  create(context) {
-    return new AddonDiscoveryManager(
-      context.addonProperties,
-      new DiscoveryQueryParser(this.runtime),
-      new KairoIdProvider(this.idRegistryFactory),
-      new DiscoveryResponder(this.runtime)
-    );
-  }
-};
-
-// src/router/init/errors.ts
-var KairoRouterInitError = class extends Error {
-  reason;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES5[reason], { cause: options.cause });
-    this.name = "KairoRouterInitError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES5 = {
-  ["NotInitialized" /* NotInitialized */]: "Kairo router is not initialized. Call init() first.",
-  ["AlreadyInitialized" /* AlreadyInitialized */]: "Kairo router has already been initialized.",
-  ["RegistrationRejected" /* RegistrationRejected */]: "Addon registration was rejected.",
-  ["RegistrationRequestNotFound" /* RegistrationRequestNotFound */]: "Registration request not found."
-};
-
-// src/router/init/registration/AddonRegistrationManager.ts
-var AddonRegistrationManager = class {
-  constructor(parser, builder, responder) {
-    this.parser = parser;
-    this.builder = builder;
-    this.responder = responder;
-  }
-  resolveRegistry(message, kairoId, addonProperties) {
-    const request = this.parser.parse(message);
-    if (request.rejects.includes(kairoId)) {
-      throw new KairoRouterInitError("RegistrationRejected" /* RegistrationRejected */);
-    }
-    if (!request.approvals.includes(kairoId)) {
-      return;
-    }
-    const registry = this.builder.build(kairoId, addonProperties);
-    return registry;
-  }
-  handleRegistrationResult(message) {
-  }
-  dispose() {
-  }
-};
-
-// src/router/init/registration/KairoRegistryBuilder.ts
-var KairoRegistryBuilder = class {
-  build(kairoId, props) {
-    return {
-      kairoId,
-      addonId: props.id,
-      name: props.header.name,
-      description: props.header.description,
-      version: props.header.version,
-      metadata: {
-        authors: props.metadata?.authors ?? [],
-        url: props.metadata?.url,
-        license: props.metadata?.license
-      },
-      requiredAddons: props.requiredAddons ?? {},
-      tags: props.tags ?? []
-    };
-  }
-};
-
-// src/router/init/registration/request/errors.ts
-var RegistrationRequestParseError = class extends Error {
-  reason;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES6[reason], { cause: options.cause });
-    this.name = "RegistrationRequestParseError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES6 = {
-  ["InvalidJSON" /* InvalidJSON */]: "Failed to parse RegistrationRequest JSON.",
-  ["InvalidStructure" /* InvalidStructure */]: "Invalid RegistrationRequest structure.",
-  ["Timeout" /* Timeout */]: "RegistrationRequest has timed out.",
-  ["FutureTimestamp" /* FutureTimestamp */]: "RegistrationRequest timestamp is in the future."
-};
-
-// src/router/init/registration/request/schema.ts
-var RegistrationRequestSchema = Type.Object(
-  {
-    approvals: Type.Array(Type.String()),
-    rejects: Type.Array(Type.String()),
-    timestamp: Type.Number()
-  },
-  {
-    additionalProperties: false
-  }
-);
-
-// src/router/init/registration/request/validate.ts
-var validateRegistrationRequest = compile(RegistrationRequestSchema);
-
-// src/router/init/registration/RegistrationRequestParser.ts
-var RegistrationRequestParser = class {
-  constructor(runtime2) {
-    this.runtime = runtime2;
-  }
-  TIMEOUT_TICKS = 10;
-  parse(message) {
-    const parsed = this.parseJson(message);
-    const currentTick = this.runtime.currentTick();
-    if (!validateRegistrationRequest(parsed)) {
-      throw new RegistrationRequestParseError(
-        "InvalidStructure" /* InvalidStructure */
-      );
-    }
-    const query = parsed;
-    if (TimestampValidator.isExpired(currentTick, query.timestamp, this.TIMEOUT_TICKS)) {
-      throw new RegistrationRequestParseError("Timeout" /* Timeout */);
-    }
-    if (TimestampValidator.isFuture(currentTick, query.timestamp)) {
-      throw new RegistrationRequestParseError(
-        "FutureTimestamp" /* FutureTimestamp */
-      );
-    }
-    return query;
-  }
-  parseJson(message) {
-    try {
-      return JSON.parse(message);
-    } catch {
-      throw new RegistrationRequestParseError(
-        "InvalidJSON" /* InvalidJSON */
-      );
-    }
-  }
-};
-
-// src/router/factories/AddonRegistrationManagerFactory.ts
-var AddonRegistrationManagerFactory = class {
+// src/router/factories/RegistrationResponderFactory.ts
+var RegistrationResponderFactory = class {
   constructor(runtime2) {
     this.runtime = runtime2;
   }
   create() {
-    return new AddonRegistrationManager(
-      new RegistrationRequestParser(this.runtime),
-      new KairoRegistryBuilder(),
-      new RegistrationResponder(this.runtime)
-    );
+    return new RegistrationResponder(this.runtime);
   }
 };
 
@@ -13393,9 +13401,9 @@ var KairoInitializerFactory = class {
       this.runtime,
       this.idRegistryFactory
     ).create(context);
-    const discoveryResponder = new DiscoveryResponder(this.runtime);
+    const discoveryResponder = new DiscoveryResponderFactory(this.runtime).create();
     const registration = new AddonRegistrationManagerFactory(this.runtime).create();
-    const registrationResponder = new RegistrationResponder(this.runtime);
+    const registrationResponder = new RegistrationResponderFactory(this.runtime).create();
     return new KairoInitializer(
       context,
       mutator,

--- a/src/router/factories/AddonDiscoveryManagerFactory.ts
+++ b/src/router/factories/AddonDiscoveryManagerFactory.ts
@@ -1,6 +1,5 @@
 import { AddonDiscoveryManager } from "../init/discovery/AddonDiscoveryManager";
 import { DiscoveryQueryParser } from "../init/discovery/DiscoveryQueryParser";
-import { DiscoveryResponder } from "../init/discovery/DiscoveryResponder";
 import { KairoIdProvider } from "../init/discovery/KairoIdProvider";
 import { KairoContext } from "../KairoContext";
 import { IdRegistryFactory } from "../types/IdRegistryFactory";
@@ -17,7 +16,6 @@ export class AddonDiscoveryManagerFactory {
             context.addonProperties,
             new DiscoveryQueryParser(this.runtime),
             new KairoIdProvider(this.idRegistryFactory),
-            new DiscoveryResponder(this.runtime),
         );
     }
 }

--- a/src/router/factories/AddonRegistrationManagerFactory.ts
+++ b/src/router/factories/AddonRegistrationManagerFactory.ts
@@ -1,7 +1,6 @@
 import { AddonRegistrationManager } from "../init/registration/AddonRegistrationManager";
 import { KairoRegistryBuilder } from "../init/registration/KairoRegistryBuilder";
 import { RegistrationRequestParser } from "../init/registration/RegistrationRequestParser";
-import { RegistrationResponder } from "../init/registration/RegistrationResponder";
 import { KairoRuntime } from "../types/KairoRuntime";
 
 export class AddonRegistrationManagerFactory {
@@ -11,7 +10,6 @@ export class AddonRegistrationManagerFactory {
         return new AddonRegistrationManager(
             new RegistrationRequestParser(this.runtime),
             new KairoRegistryBuilder(),
-            new RegistrationResponder(this.runtime),
         );
     }
 }

--- a/src/router/factories/DiscoveryResponderFactory.ts
+++ b/src/router/factories/DiscoveryResponderFactory.ts
@@ -1,0 +1,10 @@
+import { DiscoveryResponder } from "../init/discovery/DiscoveryResponder";
+import { KairoRuntime } from "../types/KairoRuntime";
+
+export class DiscoveryResponderFactory {
+    constructor(private readonly runtime: KairoRuntime) {}
+
+    create(): DiscoveryResponder {
+        return new DiscoveryResponder(this.runtime);
+    }
+}

--- a/src/router/factories/KairoInitializerFactory.ts
+++ b/src/router/factories/KairoInitializerFactory.ts
@@ -1,12 +1,12 @@
-import { DiscoveryResponder } from "../init/discovery/DiscoveryResponder";
 import { KairoInitializer } from "../init/KairoInitializer";
 import { KairoInitListener } from "../init/KairoInitListener";
-import { RegistrationResponder } from "../init/registration/RegistrationResponder";
 import { KairoContext, KairoContextMutator } from "../KairoContext";
 import { IdRegistryFactory } from "../types/IdRegistryFactory";
 import { KairoRuntime } from "../types/KairoRuntime";
 import { AddonDiscoveryManagerFactory } from "./AddonDiscoveryManagerFactory";
 import { AddonRegistrationManagerFactory } from "./AddonRegistrationManagerFactory";
+import { DiscoveryResponderFactory } from "./DiscoveryResponderFactory";
+import { RegistrationResponderFactory } from "./RegistrationResponderFactory";
 
 export class KairoInitializerFactory {
     constructor(
@@ -21,10 +21,10 @@ export class KairoInitializerFactory {
             this.runtime,
             this.idRegistryFactory,
         ).create(context);
-        const discoveryResponder = new DiscoveryResponder(this.runtime);
+        const discoveryResponder = new DiscoveryResponderFactory(this.runtime).create();
 
         const registration = new AddonRegistrationManagerFactory(this.runtime).create();
-        const registrationResponder = new RegistrationResponder(this.runtime);
+        const registrationResponder = new RegistrationResponderFactory(this.runtime).create();
 
         return new KairoInitializer(
             context,

--- a/src/router/factories/RegistrationResponderFactory.ts
+++ b/src/router/factories/RegistrationResponderFactory.ts
@@ -1,0 +1,10 @@
+import { RegistrationResponder } from "../init/registration/RegistrationResponder";
+import { KairoRuntime } from "../types/KairoRuntime";
+
+export class RegistrationResponderFactory {
+    constructor(private readonly runtime: KairoRuntime) {}
+
+    create(): RegistrationResponder {
+        return new RegistrationResponder(this.runtime);
+    }
+}

--- a/src/router/init/discovery/AddonDiscoveryManager.ts
+++ b/src/router/init/discovery/AddonDiscoveryManager.ts
@@ -1,7 +1,6 @@
 import { AddonProperties } from "../../../types/AddonProperties";
 import { Disposable } from "../../types/Disposable";
 import { DiscoveryQueryParser } from "./DiscoveryQueryParser";
-import { DiscoveryResponder } from "./DiscoveryResponder";
 import { KairoIdProvider } from "./KairoIdProvider";
 
 // kjs-router-ch 0100
@@ -10,19 +9,11 @@ export class AddonDiscoveryManager implements Disposable {
         private readonly addonProperties: AddonProperties,
         private readonly queryParser: DiscoveryQueryParser,
         private readonly idProvider: KairoIdProvider,
-        private readonly responder: DiscoveryResponder,
     ) {}
 
     resolveKairoId(message: string): string {
         const query = this.queryParser.parse(message);
         return this.idProvider.provideId(this.addonProperties, query);
-    }
-
-    handleRegistrationQuery(message: string): string {
-        const query = this.queryParser.parse(message);
-        const kairoId = this.idProvider.provideId(this.addonProperties, query);
-        this.responder.respond(kairoId);
-        return kairoId;
     }
 
     dispose(): void {}

--- a/src/router/init/registration/AddonRegistrationManager.ts
+++ b/src/router/init/registration/AddonRegistrationManager.ts
@@ -3,14 +3,12 @@ import { KairoRegistry } from "../../types/KairoRegistry";
 import { KairoRouterInitError, KairoRouterInitErrorReason } from "../errors";
 import { KairoRegistryBuilder } from "./KairoRegistryBuilder";
 import { RegistrationRequestParser } from "./RegistrationRequestParser";
-import { RegistrationResponder } from "./RegistrationResponder";
 
 // kjs-router-ch 0200
 export class AddonRegistrationManager {
     public constructor(
         private readonly parser: RegistrationRequestParser,
         private readonly builder: KairoRegistryBuilder,
-        private readonly responder: RegistrationResponder,
     ) {}
 
     resolveRegistry(
@@ -31,8 +29,6 @@ export class AddonRegistrationManager {
         const registry: KairoRegistry = this.builder.build(kairoId, addonProperties);
         return registry;
     }
-
-    handleRegistrationResult(message: string): void {}
 
     dispose(): void {}
 }


### PR DESCRIPTION
### Motivation
- Clarify CQRS boundaries by separating query/request handling from response construction so managers only perform parsing and domain resolution.
- Make factory responsibilities explicit to improve composition and make it easier to adapt/extend responder construction later.

### Description
- Removed response-side dependencies and the unused `handleRegistrationQuery`/`handleRegistrationResult` from `AddonDiscoveryManager` and `AddonRegistrationManager` so managers only parse and resolve queries/requests (`src/router/init/discovery/AddonDiscoveryManager.ts`, `src/router/init/registration/AddonRegistrationManager.ts`).
- Updated `AddonDiscoveryManagerFactory` and `AddonRegistrationManagerFactory` to construct only manager-side dependencies (`src/router/factories/AddonDiscoveryManagerFactory.ts`, `src/router/factories/AddonRegistrationManagerFactory.ts`).
- Added `DiscoveryResponderFactory` and `RegistrationResponderFactory` to centralize responder creation and keep response construction separate (`src/router/factories/DiscoveryResponderFactory.ts`, `src/router/factories/RegistrationResponderFactory.ts`).
- Updated `KairoInitializerFactory` to compose managers and responders via the new factories and adjusted imports accordingly (`src/router/factories/KairoInitializerFactory.ts`), and rebuilt library outputs (`lib/index.js`, `lib/index.d.ts`).

### Testing
- Ran `pnpm build` and the TypeScript build completed successfully with generated `lib/index.js` and `lib/index.d.ts`.
- No additional automated tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dde3b722c483339574af03750058b4)