### PR TITLE
Refactor: centralize context mutations in KairoInitializer

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -153,10 +153,9 @@ declare class DiscoveryResponder {
 declare class DiscoveryQueryHandler {
     private readonly discoveryManager;
     private readonly discoveryResponder;
-    private readonly contextMutator;
     private readonly runtime;
-    private constructor(discoveryManager: AddonDiscoveryManager, discoveryResponder: DiscoveryResponder, contextMutator: KairoContextMutator, runtime: KairoRuntime);
-    handle: (msg: string) => void;
+    private constructor(discoveryManager: AddonDiscoveryManager, discoveryResponder: DiscoveryResponder, runtime: KairoRuntime);
+    handle: (msg: string) => string;
 }
 
 declare enum KairoInitEventId {
@@ -213,20 +212,22 @@ declare class RegistrationRequestHandler {
     private readonly registrationManager;
     private readonly registrationResponder;
     private readonly context;
-    private readonly contextMutator;
     private readonly runtime;
-    private constructor(registrationManager: AddonRegistrationManager, registrationResponder: RegistrationResponder, context: KairoContext, contextMutator: KairoContextMutator, runtime: KairoRuntime);
-    handle: (msg: string) => void;
+    private constructor(registrationManager: AddonRegistrationManager, registrationResponder: RegistrationResponder, context: KairoContext, runtime: KairoRuntime);
+    handle: (msg: string) => KairoRegistry | undefined;
 }
 
 declare class KairoInitializer implements Disposable {
     private readonly initListener;
     private readonly discoveryHandler;
     private readonly registrationHandler;
+    private readonly contextMutator;
     private subscription?;
-    private constructor(initListener: KairoInitListener, discoveryHandler: DiscoveryQueryHandler, registrationHandler: RegistrationRequestHandler);
+    private constructor(initListener: KairoInitListener, discoveryHandler: DiscoveryQueryHandler, registrationHandler: RegistrationRequestHandler, contextMutator: KairoContextMutator);
     setup(): void;
     dispose(): void;
+    private handleDiscoveryQuery;
+    private handleRegistrationRequest;
 }
 
 type InitializerFactory = (context: KairoContext, mutator: KairoContextMutator) => KairoInitializer;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10259,16 +10259,17 @@ var KairoInitEventId = /* @__PURE__ */ ((KairoInitEventId2) => {
 
 // src/router/init/KairoInitializer.ts
 var KairoInitializer = class {
-  constructor(initListener, discoveryHandler, registrationHandler) {
+  constructor(initListener, discoveryHandler, registrationHandler, contextMutator) {
     this.initListener = initListener;
     this.discoveryHandler = discoveryHandler;
     this.registrationHandler = registrationHandler;
+    this.contextMutator = contextMutator;
   }
   subscription;
   setup() {
     this.initListener.setHandlers({
-      ["kairo:discovery_query" /* DiscoveryQuery */]: this.discoveryHandler.handle,
-      ["kairo:registration_request" /* RegistrationRequest */]: this.registrationHandler.handle
+      ["kairo:discovery_query" /* DiscoveryQuery */]: this.handleDiscoveryQuery,
+      ["kairo:registration_request" /* RegistrationRequest */]: this.handleRegistrationRequest
     });
     this.subscription = this.initListener.setup();
   }
@@ -10276,6 +10277,15 @@ var KairoInitializer = class {
     this.subscription?.dispose();
     this.subscription = void 0;
   }
+  handleDiscoveryQuery = (message) => {
+    const kairoId = this.discoveryHandler.handle(message);
+    this.contextMutator.setKairoId(kairoId);
+  };
+  handleRegistrationRequest = (message) => {
+    const registry = this.registrationHandler.handle(message);
+    if (!registry) return;
+    this.contextMutator.setKairoRegistry(registry);
+  };
 };
 
 // src/router/factories/KairoInitializerFactory.ts
@@ -10299,19 +10309,14 @@ var KairoInitializerFactory = class {
     const registrationResponder = this.registrationResponderFactory.create(this.runtime);
     return new KairoInitializer(
       listener,
-      this.discoveryHandlerFactory.create(
-        discovery,
-        discoveryResponder,
-        mutator,
-        this.runtime
-      ),
+      this.discoveryHandlerFactory.create(discovery, discoveryResponder, this.runtime),
       this.registrationHandlerFactory.create(
         registration,
         registrationResponder,
         context,
-        mutator,
         this.runtime
-      )
+      ),
+      mutator
     );
   }
 };
@@ -13124,16 +13129,15 @@ var AddonDiscoveryManagerFactory = class {
 
 // src/router/init/discovery/DiscoveryQueryHandler.ts
 var DiscoveryQueryHandler = class {
-  constructor(discoveryManager, discoveryResponder, contextMutator, runtime2) {
+  constructor(discoveryManager, discoveryResponder, runtime2) {
     this.discoveryManager = discoveryManager;
     this.discoveryResponder = discoveryResponder;
-    this.contextMutator = contextMutator;
     this.runtime = runtime2;
   }
   handle = (msg) => {
     const kairoId = this.discoveryManager.resolveKairoId(msg, this.runtime.currentTick());
-    this.contextMutator.setKairoId(kairoId);
     this.discoveryResponder.respond(kairoId);
+    return kairoId;
   };
 };
 
@@ -13141,8 +13145,8 @@ var DiscoveryQueryHandler = class {
 var DiscoveryQueryHandlerFactory = class {
   constructor() {
   }
-  create(discovery, responder, mutator, runtime2) {
-    return new DiscoveryQueryHandler(discovery, responder, mutator, runtime2);
+  create(discovery, responder, runtime2) {
+    return new DiscoveryQueryHandler(discovery, responder, runtime2);
   }
 };
 
@@ -13339,11 +13343,10 @@ var AddonRegistrationManagerFactory = class {
 
 // src/router/init/registration/RegistrationRequestHandler.ts
 var RegistrationRequestHandler = class {
-  constructor(registrationManager, registrationResponder, context, contextMutator, runtime2) {
+  constructor(registrationManager, registrationResponder, context, runtime2) {
     this.registrationManager = registrationManager;
     this.registrationResponder = registrationResponder;
     this.context = context;
-    this.contextMutator = contextMutator;
     this.runtime = runtime2;
   }
   handle = (msg) => {
@@ -13354,8 +13357,8 @@ var RegistrationRequestHandler = class {
       this.context.addonProperties
     );
     if (!registry) return;
-    this.contextMutator.setKairoRegistry(registry);
     this.registrationResponder.respond(registry);
+    return registry;
   };
 };
 
@@ -13363,8 +13366,8 @@ var RegistrationRequestHandler = class {
 var RegistrationRequestHandlerFactory = class {
   constructor() {
   }
-  create(registration, responder, context, mutator, runtime2) {
-    return new RegistrationRequestHandler(registration, responder, context, mutator, runtime2);
+  create(registration, responder, context, runtime2) {
+    return new RegistrationRequestHandler(registration, responder, context, runtime2);
   }
 };
 

--- a/src/router/factories/KairoInitializerFactory.ts
+++ b/src/router/factories/KairoInitializerFactory.ts
@@ -34,19 +34,14 @@ export class KairoInitializerFactory {
 
         return new KairoInitializer(
             listener,
-            this.discoveryHandlerFactory.create(
-                discovery,
-                discoveryResponder,
-                mutator,
-                this.runtime,
-            ),
+            this.discoveryHandlerFactory.create(discovery, discoveryResponder, this.runtime),
             this.registrationHandlerFactory.create(
                 registration,
                 registrationResponder,
                 context,
-                mutator,
                 this.runtime,
             ),
+            mutator,
         );
     }
 }

--- a/src/router/init/KairoInitializer.ts
+++ b/src/router/init/KairoInitializer.ts
@@ -1,4 +1,5 @@
 import { Disposable } from "../types/Disposable";
+import { KairoContextMutator } from "../KairoContext";
 import { DiscoveryQueryHandler } from "./discovery/DiscoveryQueryHandler";
 import { KairoInitEventId } from "./KairoInitEventId";
 import { KairoInitListener } from "./KairoInitListener";
@@ -12,12 +13,13 @@ export class KairoInitializer implements Disposable {
         private readonly initListener: KairoInitListener,
         private readonly discoveryHandler: DiscoveryQueryHandler,
         private readonly registrationHandler: RegistrationRequestHandler,
+        private readonly contextMutator: KairoContextMutator,
     ) {}
 
     setup(): void {
         this.initListener.setHandlers({
-            [KairoInitEventId.DiscoveryQuery]: this.discoveryHandler.handle,
-            [KairoInitEventId.RegistrationRequest]: this.registrationHandler.handle,
+            [KairoInitEventId.DiscoveryQuery]: this.handleDiscoveryQuery,
+            [KairoInitEventId.RegistrationRequest]: this.handleRegistrationRequest,
         });
 
         this.subscription = this.initListener.setup();
@@ -27,4 +29,16 @@ export class KairoInitializer implements Disposable {
         this.subscription?.dispose();
         this.subscription = undefined;
     }
+
+    private handleDiscoveryQuery = (message: string): void => {
+        const kairoId = this.discoveryHandler.handle(message);
+        this.contextMutator.setKairoId(kairoId);
+    };
+
+    private handleRegistrationRequest = (message: string): void => {
+        const registry = this.registrationHandler.handle(message);
+        if (!registry) return;
+
+        this.contextMutator.setKairoRegistry(registry);
+    };
 }

--- a/src/router/init/discovery/DiscoveryQueryHandler.ts
+++ b/src/router/init/discovery/DiscoveryQueryHandler.ts
@@ -1,4 +1,3 @@
-import { KairoContextMutator } from "../../KairoContext";
 import { KairoRuntime } from "../../types/KairoRuntime";
 import { AddonDiscoveryManager } from "./AddonDiscoveryManager";
 import { DiscoveryResponder } from "./DiscoveryResponder";
@@ -7,14 +6,13 @@ export class DiscoveryQueryHandler {
     constructor(
         private readonly discoveryManager: AddonDiscoveryManager,
         private readonly discoveryResponder: DiscoveryResponder,
-        private readonly contextMutator: KairoContextMutator,
         private readonly runtime: KairoRuntime,
     ) {}
 
-    handle = (msg: string): void => {
+    handle = (msg: string): string => {
         const kairoId = this.discoveryManager.resolveKairoId(msg, this.runtime.currentTick());
 
-        this.contextMutator.setKairoId(kairoId);
         this.discoveryResponder.respond(kairoId);
+        return kairoId;
     };
 }

--- a/src/router/init/discovery/factories/DiscoveryQueryHandlerFactory.ts
+++ b/src/router/init/discovery/factories/DiscoveryQueryHandlerFactory.ts
@@ -1,4 +1,3 @@
-import { KairoContextMutator } from "../../../KairoContext";
 import { KairoRuntime } from "../../../types/KairoRuntime";
 import { AddonDiscoveryManager } from "../AddonDiscoveryManager";
 import { DiscoveryQueryHandler } from "../DiscoveryQueryHandler";
@@ -10,9 +9,8 @@ export class DiscoveryQueryHandlerFactory {
     create(
         discovery: AddonDiscoveryManager,
         responder: DiscoveryResponder,
-        mutator: KairoContextMutator,
         runtime: KairoRuntime,
     ): DiscoveryQueryHandler {
-        return new DiscoveryQueryHandler(discovery, responder, mutator, runtime);
+        return new DiscoveryQueryHandler(discovery, responder, runtime);
     }
 }

--- a/src/router/init/registration/RegistrationRequestHandler.ts
+++ b/src/router/init/registration/RegistrationRequestHandler.ts
@@ -1,5 +1,6 @@
-import { KairoContext, KairoContextMutator } from "../../KairoContext";
+import { KairoContext } from "../../KairoContext";
 import { KairoRuntime } from "../../types/KairoRuntime";
+import { KairoRegistry } from "../../types/KairoRegistry";
 import { AddonRegistrationManager } from "./AddonRegistrationManager";
 import { RegistrationResponder } from "./RegistrationResponder";
 
@@ -8,11 +9,10 @@ export class RegistrationRequestHandler {
         private readonly registrationManager: AddonRegistrationManager,
         private readonly registrationResponder: RegistrationResponder,
         private readonly context: KairoContext,
-        private readonly contextMutator: KairoContextMutator,
         private readonly runtime: KairoRuntime,
     ) {}
 
-    handle = (msg: string): void => {
+    handle = (msg: string): KairoRegistry | undefined => {
         const registry = this.registrationManager.resolveRegistry(
             msg,
             this.runtime.currentTick(),
@@ -22,7 +22,7 @@ export class RegistrationRequestHandler {
 
         if (!registry) return;
 
-        this.contextMutator.setKairoRegistry(registry);
         this.registrationResponder.respond(registry);
+        return registry;
     };
 }

--- a/src/router/init/registration/factories/RegistrationRequestHandlerFactory.ts
+++ b/src/router/init/registration/factories/RegistrationRequestHandlerFactory.ts
@@ -1,4 +1,4 @@
-import { KairoContext, KairoContextMutator } from "../../../KairoContext";
+import { KairoContext } from "../../../KairoContext";
 import { KairoRuntime } from "../../../types/KairoRuntime";
 import { AddonRegistrationManager } from "../AddonRegistrationManager";
 import { RegistrationRequestHandler } from "../RegistrationRequestHandler";
@@ -11,9 +11,8 @@ export class RegistrationRequestHandlerFactory {
         registration: AddonRegistrationManager,
         responder: RegistrationResponder,
         context: KairoContext,
-        mutator: KairoContextMutator,
         runtime: KairoRuntime,
     ): RegistrationRequestHandler {
-        return new RegistrationRequestHandler(registration, responder, context, mutator, runtime);
+        return new RegistrationRequestHandler(registration, responder, context, runtime);
     }
 }


### PR DESCRIPTION
### Motivation
- Separate responsibilities so `Handler` implementations remain pure (logic + responding) and `Initializer` handles wiring and state mutation orchestration.
- Ensure only the initializer performs context mutations (`ContextMutator`) to avoid scattered state changes during init flow.

### Description
- Removed `KairoContextMutator` usage from `DiscoveryQueryHandler` and made `handle` return the computed `kairoId` after responding (`src/router/init/discovery/DiscoveryQueryHandler.ts`).
- Removed `KairoContextMutator` usage from `RegistrationRequestHandler` and made `handle` return `KairoRegistry | undefined` after responding (`src/router/init/registration/RegistrationRequestHandler.ts`).
- Injected `KairoContextMutator` into `KairoInitializer` and added orchestration methods that call handlers, then perform `setKairoId` / `setKairoRegistry` as appropriate (`src/router/init/KairoInitializer.ts`).
- Updated factories to match new constructor signatures and wiring: `DiscoveryQueryHandlerFactory`, `RegistrationRequestHandlerFactory`, and `KairoInitializerFactory` were adjusted to stop passing mutator into handlers and to pass the mutator only to the initializer (`src/router/init/discovery/factories/DiscoveryQueryHandlerFactory.ts`, `src/router/init/registration/factories/RegistrationRequestHandlerFactory.ts`, `src/router/factories/KairoInitializerFactory.ts`).
- Rebuilt generated artifacts so the public declarations reflect the refactor (`lib/index.js`, `lib/index.d.ts`).

### Testing
- Ran `pnpm run build` and the `tsup` build completed successfully with both ESM and DTS outputs (build and d.ts generation succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de00a1dd308333a745d052c2292d03)