### PR TITLE
Use Set for init event check, add injectable RNG to KairoIdProvider, and attach validation causes

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -144,12 +144,14 @@ interface IdRegistryFactory {
     create(objectiveId: string): IdRegistry;
 }
 
+type RandomSource = () => number;
 declare class KairoIdProvider {
     private readonly idRegistryFactory;
+    private readonly random;
     private CHARSET;
     private PREFIX_LENGTH;
     private ID_LENGTH;
-    private constructor(idRegistryFactory: IdRegistryFactory);
+    private constructor(idRegistryFactory: IdRegistryFactory, random?: RandomSource);
     provideId(properties: AddonProperties, query: DiscoveryQuery): string;
     private generateId;
     private hash;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10330,6 +10330,7 @@ var KairoInitializerFactory = class {
 };
 
 // src/router/init/KairoInitListener.ts
+var KAIRO_INIT_EVENT_ID_SET = new Set(Object.values(KairoInitEventId));
 var KairoInitListener = class {
   constructor(runtime2) {
     this.runtime = runtime2;
@@ -10346,7 +10347,7 @@ var KairoInitListener = class {
     this.handlers[id]?.(message);
   };
   isKairoInitEventId(id) {
-    return Object.values(KairoInitEventId).includes(id);
+    return KAIRO_INIT_EVENT_ID_SET.has(id);
   }
 };
 
@@ -13083,8 +13084,9 @@ var DEFAULT_MESSAGES2 = {
 
 // src/router/init/discovery/KairoIdProvider.ts
 var KairoIdProvider = class {
-  constructor(idRegistryFactory2) {
+  constructor(idRegistryFactory2, random = Math.random) {
     this.idRegistryFactory = idRegistryFactory2;
+    this.random = random;
   }
   CHARSET = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789?_-().";
   PREFIX_LENGTH = 8;
@@ -13108,7 +13110,7 @@ var KairoIdProvider = class {
     const chars = this.CHARSET;
     let result = "";
     for (let i = 0; i < length; i++) {
-      result += chars[Math.random() * chars.length | 0];
+      result += chars[this.random() * chars.length | 0];
     }
     return result;
   }
@@ -13289,7 +13291,8 @@ var RegistrationRequestParser = class {
     const parsed = this.parseJson(message);
     if (!validateRegistrationRequest(parsed)) {
       throw new RegistrationRequestParseError(
-        "InvalidStructure" /* InvalidStructure */
+        "InvalidStructure" /* InvalidStructure */,
+        { cause: toError(validateRegistrationRequest.errors) }
       );
     }
     const query = parsed;

--- a/src/router/init/KairoInitListener.ts
+++ b/src/router/init/KairoInitListener.ts
@@ -4,6 +4,8 @@ import { KairoInitEventId } from "./KairoInitEventId";
 
 type Handler = (message: string) => void;
 
+const KAIRO_INIT_EVENT_ID_SET = new Set<string>(Object.values(KairoInitEventId));
+
 export class KairoInitListener {
     private handlers: Partial<Record<KairoInitEventId, Handler>> = {};
     constructor(private readonly runtime: KairoRuntime) {}
@@ -23,6 +25,6 @@ export class KairoInitListener {
     };
 
     private isKairoInitEventId(id: string): id is KairoInitEventId {
-        return Object.values(KairoInitEventId).includes(id as any);
+        return KAIRO_INIT_EVENT_ID_SET.has(id);
     }
 }

--- a/src/router/init/discovery/KairoIdProvider.ts
+++ b/src/router/init/discovery/KairoIdProvider.ts
@@ -4,13 +4,18 @@ import { ProvideKairoIdError, ProvideKairoIdErrorReason } from "./idProvider/err
 import { DiscoveryQuery } from "./query/schema";
 
 // kjs-router-ch 0104
+type RandomSource = () => number;
+
 export class KairoIdProvider {
     private CHARSET =
         "abcdefghijklmnopqrstuvwxyz" + "ABCDEFGHIJKLMNOPQRSTUVWXYZ" + "0123456789" + "?_-().";
     private PREFIX_LENGTH = 8;
     private ID_LENGTH = 16;
 
-    constructor(private readonly idRegistryFactory: IdRegistryFactory) {}
+    constructor(
+        private readonly idRegistryFactory: IdRegistryFactory,
+        private readonly random: RandomSource = Math.random,
+    ) {}
 
     provideId(properties: AddonProperties, query: DiscoveryQuery): string {
         const registry = this.idRegistryFactory.create(query.idNamespace);
@@ -39,7 +44,7 @@ export class KairoIdProvider {
         let result = "";
 
         for (let i = 0; i < length; i++) {
-            result += chars[(Math.random() * chars.length) | 0];
+            result += chars[(this.random() * chars.length) | 0];
         }
 
         return result;

--- a/src/router/init/registration/RegistrationRequestParser.ts
+++ b/src/router/init/registration/RegistrationRequestParser.ts
@@ -1,4 +1,5 @@
 import { TimestampValidator } from "../../../utils/TimestampValidator";
+import { toError } from "../../../utils/toError";
 import {
     RegistrationRequestParseError,
     RegistrationRequestParseErrorReason,
@@ -16,6 +17,7 @@ export class RegistrationRequestParser {
         if (!validateRegistrationRequest(parsed)) {
             throw new RegistrationRequestParseError(
                 RegistrationRequestParseErrorReason.InvalidStructure,
+                { cause: toError(validateRegistrationRequest.errors) },
             );
         }
 


### PR DESCRIPTION
### Motivation
- Improve performance and stability of init event detection by avoiding repeated array allocations and O(n) lookups on the hot path.
- Make addon ID generation deterministic and testable by allowing an injectable random source instead of calling `Math.random` directly.
- Surface AJV/validation diagnostics when registration parsing fails so callers get the underlying validation errors as `cause` on the thrown error.

### Description
- Precompute `KAIRO_INIT_EVENT_ID_SET` and replace `Object.values(KairoInitEventId).includes` with `KAIRO_INIT_EVENT_ID_SET.has` in `KairoInitListener` to use O(1) lookups.
- Introduce a `RandomSource` type and add an optional `random` constructor parameter (defaulting to `Math.random`) to `KairoIdProvider`, and replace direct `Math.random` calls with `this.random()`.
- Include AJV validation errors as the `cause` when throwing `RegistrationRequestParseError` by importing and using `toError(validateRegistrationRequest.errors)`.
- Update compiled outputs under `lib/` and type declarations to reflect the new `KairoIdProvider` constructor signature and added types.

### Testing
- Ran the unit test suite with `npm test`, which completed successfully.
- Performed a TypeScript build and type checking with `npm run build`, which succeeded.
- Verified no regressions in the modified parsing and ID generation code paths via the automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de04e6e9388333b348c51ffbf4ef8d)