### PR TITLE
Tighten init timestamp schema validation

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -123,7 +123,7 @@ declare class KairoInitListener {
 }
 
 declare const DiscoveryQuerySchema: _sinclair_typebox.TObject<{
-    timestamp: _sinclair_typebox.TNumber;
+    timestamp: _sinclair_typebox.TInteger;
     idNamespace: _sinclair_typebox.TString;
 }>;
 type DiscoveryQuery = Static<typeof DiscoveryQuerySchema>;
@@ -178,7 +178,7 @@ declare class KairoRegistryBuilder {
 declare const RegistrationRequestSchema: _sinclair_typebox.TObject<{
     approvals: _sinclair_typebox.TArray<_sinclair_typebox.TString>;
     rejects: _sinclair_typebox.TArray<_sinclair_typebox.TString>;
-    timestamp: _sinclair_typebox.TNumber;
+    timestamp: _sinclair_typebox.TInteger;
 }>;
 type RegistrationRequest = Static<typeof RegistrationRequestSchema>;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -13028,7 +13028,7 @@ var Type = type_exports2;
 // src/router/init/discovery/query/schema.ts
 var DiscoveryQuerySchema = Type.Object(
   {
-    timestamp: Type.Number(),
+    timestamp: Type.Integer({ minimum: 0 }),
     idNamespace: Type.String()
   },
   {
@@ -13272,7 +13272,7 @@ var RegistrationRequestSchema = Type.Object(
   {
     approvals: Type.Array(Type.String()),
     rejects: Type.Array(Type.String()),
-    timestamp: Type.Number()
+    timestamp: Type.Integer({ minimum: 0 })
   },
   {
     additionalProperties: false

--- a/src/router/init/discovery/query/schema.ts
+++ b/src/router/init/discovery/query/schema.ts
@@ -2,7 +2,7 @@ import { Static, Type } from "@sinclair/typebox";
 
 export const DiscoveryQuerySchema = Type.Object(
     {
-        timestamp: Type.Number(),
+        timestamp: Type.Integer({ minimum: 0 }),
         idNamespace: Type.String(),
     },
     {

--- a/src/router/init/registration/request/schema.ts
+++ b/src/router/init/registration/request/schema.ts
@@ -4,7 +4,7 @@ export const RegistrationRequestSchema = Type.Object(
     {
         approvals: Type.Array(Type.String()),
         rejects: Type.Array(Type.String()),
-        timestamp: Type.Number(),
+        timestamp: Type.Integer({ minimum: 0 }),
     },
     {
         additionalProperties: false,


### PR DESCRIPTION
### Motivation
- Prevent non-integer or negative `timestamp` values from passing validation in the init flow by making the schema explicit about integer and non-negative semantics.

### Description
- Replace `timestamp: Type.Number()` with `timestamp: Type.Integer({ minimum: 0 })` in `DiscoveryQuerySchema` and `RegistrationRequestSchema`, and regenerate `lib/` build artifacts.

### Testing
- Ran `pnpm run build` which completed successfully (ESM + DTS build and postbuild patching).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de075dbf0c83338e5335adc98f4e09)