### PR TITLE
Delay router init event handling until worldLoad fires

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -117,6 +117,7 @@ interface KairoRuntime {
     currentTick(): number;
     send(id: string, message: string): void;
     subscribe(handler: (id: string, message: string) => void): Disposable;
+    subscribeWorldLoad(handler: () => void): Disposable;
     createIdRegistry(objectiveId: string): IdRegistry;
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -10902,7 +10902,11 @@ ${contextFunctionCode}`,
 });
 
 // src/minecraft/MinecraftRuntime.ts
-import { ScriptEventSource, system } from "@minecraft/server";
+import {
+  ScriptEventSource,
+  system,
+  world as world2
+} from "@minecraft/server";
 
 // src/minecraft/ScoreboardIdRegistry.ts
 import { world } from "@minecraft/server";
@@ -10942,6 +10946,17 @@ var MinecraftRuntime = class {
     return {
       dispose: () => {
         system.afterEvents.scriptEventReceive.unsubscribe(listener);
+      }
+    };
+  }
+  subscribeWorldLoad(handler) {
+    const listener = (_ev) => {
+      handler();
+    };
+    world2.afterEvents.worldLoad.subscribe(listener);
+    return {
+      dispose: () => {
+        world2.afterEvents.worldLoad.unsubscribe(listener);
       }
     };
   }
@@ -13803,17 +13818,39 @@ var KairoIdProvider = class {
 var KAIRO_INIT_EVENT_ID_SET = new Set(Object.values(KairoInitEventId));
 var KairoInitListener = class {
   handlers = {};
+  hasWorldLoaded = false;
+  pendingMessages = [];
   constructor() {
   }
   setHandlers(handlers) {
     this.handlers = handlers;
   }
   setup(runtime) {
-    return runtime.subscribe(this.onEvent);
+    const eventSubscription = runtime.subscribe(this.onEvent);
+    const worldLoadSubscription = runtime.subscribeWorldLoad(this.onWorldLoad);
+    return {
+      dispose: () => {
+        eventSubscription.dispose();
+        worldLoadSubscription.dispose();
+      }
+    };
   }
   onEvent = (id, message) => {
     if (!this.isKairoInitEventId(id)) return;
+    if (!this.hasWorldLoaded) {
+      this.pendingMessages.push({ id, message });
+      return;
+    }
     this.handlers[id]?.(message);
+  };
+  onWorldLoad = () => {
+    if (this.hasWorldLoaded) return;
+    this.hasWorldLoaded = true;
+    const messages = this.pendingMessages;
+    this.pendingMessages = [];
+    for (const { id, message } of messages) {
+      this.handlers[id]?.(message);
+    }
   };
   isKairoInitEventId(id) {
     return KAIRO_INIT_EVENT_ID_SET.has(id);

--- a/src/minecraft/MinecraftRuntime.ts
+++ b/src/minecraft/MinecraftRuntime.ts
@@ -1,4 +1,10 @@
-import { ScriptEventCommandMessageAfterEvent, ScriptEventSource, system } from "@minecraft/server";
+import {
+    ScriptEventCommandMessageAfterEvent,
+    ScriptEventSource,
+    system,
+    world,
+    WorldLoadAfterEvent,
+} from "@minecraft/server";
 import { Disposable } from "../router/types/Disposable";
 import { KairoRuntime } from "../router/types/KairoRuntime";
 import { ScoreboardIdRegistry } from "./ScoreboardIdRegistry";
@@ -22,6 +28,20 @@ export class MinecraftRuntime implements KairoRuntime {
         return {
             dispose: () => {
                 system.afterEvents.scriptEventReceive.unsubscribe(listener);
+            },
+        };
+    }
+
+    subscribeWorldLoad(handler: () => void): Disposable {
+        const listener = (_ev: WorldLoadAfterEvent) => {
+            handler();
+        };
+
+        world.afterEvents.worldLoad.subscribe(listener);
+
+        return {
+            dispose: () => {
+                world.afterEvents.worldLoad.unsubscribe(listener);
             },
         };
     }

--- a/src/router/init/KairoInitListener.ts
+++ b/src/router/init/KairoInitListener.ts
@@ -8,6 +8,8 @@ const KAIRO_INIT_EVENT_ID_SET = new Set<string>(Object.values(KairoInitEventId))
 
 export class KairoInitListener {
     private handlers: Partial<Record<KairoInitEventId, Handler>> = {};
+    private hasWorldLoaded = false;
+    private pendingMessages: { id: KairoInitEventId; message: string }[] = [];
     constructor() {}
 
     setHandlers(handlers: Partial<Record<KairoInitEventId, Handler>>): void {
@@ -15,13 +17,39 @@ export class KairoInitListener {
     }
 
     setup(runtime: KairoRuntime): Disposable {
-        return runtime.subscribe(this.onEvent);
+        const eventSubscription = runtime.subscribe(this.onEvent);
+        const worldLoadSubscription = runtime.subscribeWorldLoad(this.onWorldLoad);
+
+        return {
+            dispose: () => {
+                eventSubscription.dispose();
+                worldLoadSubscription.dispose();
+            },
+        };
     }
 
     private onEvent = (id: string, message: string) => {
         if (!this.isKairoInitEventId(id)) return;
 
+        if (!this.hasWorldLoaded) {
+            this.pendingMessages.push({ id, message });
+            return;
+        }
+
         this.handlers[id]?.(message);
+    };
+
+    private onWorldLoad = () => {
+        if (this.hasWorldLoaded) return;
+
+        this.hasWorldLoaded = true;
+
+        const messages = this.pendingMessages;
+        this.pendingMessages = [];
+
+        for (const { id, message } of messages) {
+            this.handlers[id]?.(message);
+        }
     };
 
     private isKairoInitEventId(id: string): id is KairoInitEventId {

--- a/src/router/types/KairoRuntime.ts
+++ b/src/router/types/KairoRuntime.ts
@@ -9,6 +9,7 @@ export interface KairoRuntime {
     // アドオン間通信のための送受信機能
     send(id: string, message: string): void;
     subscribe(handler: (id: string, message: string) => void): Disposable;
+    subscribeWorldLoad(handler: () => void): Disposable;
 
     // kairoId の生成に使う
     createIdRegistry(objectiveId: string): IdRegistry;


### PR DESCRIPTION
### Motivation
- `scriptEventReceive` can deliver discovery/registration messages before the Minecraft world is fully loaded, causing handlers to run too early.
- The change preserves incoming init events while delaying their handling until the world is ready.

### Description
- Added `subscribeWorldLoad(handler: () => void): Disposable` to the `KairoRuntime` interface to express a world-load hook in the runtime abstraction.
- Implemented `subscribeWorldLoad` in `MinecraftRuntime` using `world.afterEvents.worldLoad` to wire the runtime to the real Minecraft world-load event.
- Updated `KairoInitListener` to queue Kairo init script events until `worldLoad` fires, then flush queued messages in order and ensure both subscriptions are disposed.
- Rebuilt library artifacts so the API change is reflected in `lib/index.js` and `lib/index.d.ts`.

### Testing
- Ran `pnpm run build`, which completed successfully and produced updated `lib/index.js` and `lib/index.d.ts` (DTS build also succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e077e0cd5c83339799d285a77459ab)