### PR TITLE
Update README to document `tsup` build and d.ts post-processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This project uses **pnpm** as the package manager.
 - Install dependencies: `pnpm install`
 - Build: `pnpm run build`
 
-The build pipeline compiles type definitions with `tsc` and bundles JavaScript with `esbuild` (`build.mjs`).
+The build pipeline uses `tsup` to bundle JavaScript (ESM) and emit type declarations, then runs `.build/postprocess-dts.js` to post-process the generated `lib/index.d.ts`.


### PR DESCRIPTION
### Motivation
- Update the repository documentation to reflect the current build pipeline which now uses `tsup` and a post-processing step for type declarations.

### Description
- Replace the README build pipeline description to state that `tsup` bundles JavaScript (ESM) and emits type declarations, and that `.build/postprocess-dts.js` is run to post-process the generated `lib/index.d.ts`.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0986e79648333820b687f418094b5)