### PR TITLE
Fix d.ts postprocess pruning to keep AddonProperties-related types

### DIFF
--- a/.build/pruneUnused.js
+++ b/.build/pruneUnused.js
@@ -2,18 +2,30 @@ import { SyntaxKind } from "ts-morph";
 
 export function pruneUnused(source, rootNames) {
     const roots = new Set(rootNames);
-
+    const declarations = [
+        ...source.getClasses(),
+        ...source.getInterfaces(),
+        ...source.getTypeAliases(),
+    ];
+    const declarationNames = new Set(
+        declarations.map((declaration) => declaration.getName()).filter(Boolean),
+    );
     const typeRefsMap = new Map();
 
-    for (const cls of source.getClasses()) {
-        const name = cls.getName();
+    for (const declaration of declarations) {
+        const name = declaration.getName();
         if (!name) continue;
 
         const refs = new Set();
 
-        cls.forEachDescendant((node) => {
-            if (node.getKind() === SyntaxKind.TypeReference) {
-                refs.add(node.getText());
+        declaration.forEachDescendant((node) => {
+            if (node.getKind() !== SyntaxKind.TypeReference) return;
+
+            const typeNameNode = node.getFirstChildByKind(SyntaxKind.Identifier);
+            const ref = typeNameNode?.getText();
+
+            if (ref && declarationNames.has(ref) && ref !== name) {
+                refs.add(ref);
             }
         });
 

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -13,7 +13,33 @@ interface AddonProperties {
     readonly requiredAddons?: RequiredAddons;
     readonly tags?: SupportedTag[];
 }
-
+interface AddonMetadata {
+    readonly authors?: string[];
+    readonly url?: string;
+    readonly license?: string;
+}
+interface AddonHeader {
+    readonly name: string;
+    readonly description: string;
+    readonly version: SemVer;
+    readonly min_engine_version: EngineVersion;
+}
+interface SemVer {
+    readonly major: number;
+    readonly minor: number;
+    readonly patch: number;
+    readonly prerelease?: string;
+    readonly build?: string;
+}
+interface EngineVersion {
+    readonly major: number;
+    readonly minor: number;
+    readonly patch: number;
+}
+interface ManifestDependency {
+    readonly module_name: MinecraftModule;
+    readonly version: string;
+}
 declare enum MinecraftModule {
     Server = "@minecraft/server",
     ServerUi = "@minecraft/server-ui",
@@ -25,6 +51,9 @@ declare enum MinecraftModule {
     DebugUtilities = "@minecraft/debug-utilities",
     Diagnostics = "@minecraft/diagnostics",
     ServerGraphics = "@minecraft/server-graphics"
+}
+interface RequiredAddons {
+    readonly [addonId: string]: string;
 }
 
 interface KairoRegistry {
@@ -51,6 +80,23 @@ declare class KairoContext {
     get kairoId(): string;
     get kairoRegistry(): KairoRegistry;
     isRegistered(): boolean;
+}
+
+interface Disposable {
+    dispose(): void;
+}
+
+interface IdRegistry {
+    has(id: string): boolean;
+    register(id: string): void;
+}
+
+interface KairoRuntime {
+    currentTick(): number;
+    send(id: string, message: string): void;
+    receive(handler: (id: string, message: string) => void): Disposable;
+    onReady(handler: () => void): Disposable;
+    createIdRegistry(objectiveId: string): IdRegistry;
 }
 
 type RuntimeOption = KairoRuntime | "minecraft";


### PR DESCRIPTION
### Motivation
- The post-processing step that prunes unused declarations from `lib/index.d.ts` was only analyzing classes and therefore removed interfaces/types referenced by `addonProperties` such as `AddonMetadata`, `AddonHeader`, `SemVer`, and `EngineVersion`.
- The change aims to make the pruning logic aware of interfaces and type aliases so that declarations reachable from the configured roots (e.g. `KairoContext`, `KairoRouter`) are preserved.

### Description
- Updated `.build/pruneUnused.js` to collect declarations from `source.getClasses()`, `source.getInterfaces()`, and `source.getTypeAliases()` instead of classes only. 
- Built a `declarationNames` set of available declaration identifiers and changed the type-reference walk to extract the referenced identifier (via `getFirstChildByKind(SyntaxKind.Identifier)`) and keep only references that resolve to known declarations. 
- The reachability expansion remains the same but now operates over the broader declaration graph so dependent interfaces/types reachable from `AddonProperties` are retained. 
- Regenerated `lib/index.d.ts` via the existing `postprocess-dts.js` pipeline so the DTS output now includes `AddonProperties` and its nested types.

### Testing
- Ran the build with `pnpm run build`, and the ESM and DTS steps succeeded and the `postprocess-dts.js` step completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e0ae0412ac833399bcf4d3d827e74f)