### PR TITLE
Injectable Random for kairoId generation and seeded RNG in Minecraft runtime

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -91,12 +91,17 @@ interface IdRegistry {
     register(id: string): void;
 }
 
+interface Random {
+    next(): number;
+}
+
 interface KairoRuntime {
     currentTick(): number;
     send(id: string, message: string): void;
     receive(handler: (id: string, message: string) => void): Disposable;
     onReady(handler: () => void): Disposable;
     createIdRegistry(objectiveId: string): IdRegistry;
+    createRandom?(): Random;
 }
 
 type RuntimeOption = KairoRuntime | "minecraft";

--- a/lib/index.js
+++ b/lib/index.js
@@ -10929,8 +10929,23 @@ var ScoreboardIdRegistry = class {
   }
 };
 
+// src/utils/SeedRandom.ts
+var import_seedrandom = __toESM(require_seedrandom2(), 1);
+var SeedRandom = class {
+  rng;
+  constructor(seed) {
+    this.rng = (0, import_seedrandom.default)(seed);
+  }
+  next() {
+    return this.rng();
+  }
+};
+
 // src/minecraft/MinecraftRuntime.ts
 var MinecraftRuntime = class {
+  constructor(options = {}) {
+    this.options = options;
+  }
   currentTick() {
     return system.currentTick;
   }
@@ -10963,11 +10978,15 @@ var MinecraftRuntime = class {
   createIdRegistry(objectiveId) {
     return new ScoreboardIdRegistry(objectiveId);
   }
+  createRandom() {
+    return new SeedRandom(this.options.randomSeed);
+  }
 };
 
 // src/router/init/errors.ts
 var KairoRouterInitError = class extends Error {
   reason;
+  cause;
   constructor(reason, options = {}) {
     super(DEFAULT_MESSAGES[reason], { cause: options.cause });
     this.name = "KairoRouterInitError";
@@ -10979,18 +10998,6 @@ var DEFAULT_MESSAGES = {
   ["AlreadyInitialized" /* AlreadyInitialized */]: "Kairo router has already been initialized.",
   ["RegistrationRejected" /* RegistrationRejected */]: "Addon registration was rejected.",
   ["RegistrationRequestNotFound" /* RegistrationRequestNotFound */]: "Registration request not found."
-};
-
-// src/utils/SeedRandom.ts
-var import_seedrandom = __toESM(require_seedrandom2(), 1);
-var SeedRandom = class {
-  rng;
-  constructor(seed) {
-    this.rng = (0, import_seedrandom.default)(seed);
-  }
-  next() {
-    return this.rng();
-  }
 };
 
 // src/utils/TimestampValidator.ts
@@ -11014,6 +11021,7 @@ function toError(e) {
 // src/router/init/discovery/query/errors.ts
 var DiscoveryQueryParseError = class extends Error {
   reason;
+  cause;
   constructor(reason, options = {}) {
     super(DEFAULT_MESSAGES2[reason], { cause: options.cause });
     this.name = "DiscoveryQueryParseError";
@@ -13733,7 +13741,7 @@ var import_fast_json_stringify = __toESM(require_fast_json_stringify(), 1);
 var DiscoveryResponseSchema = Type.Object(
   {
     kairoId: Type.String(),
-    timestamp: Type.Number()
+    timestamp: Type.Integer({ minimum: 0 })
   },
   { additionalProperties: false }
 );
@@ -13764,6 +13772,7 @@ var DiscoveryResponder = class {
 // src/router/init/discovery/idProvider/errors.ts
 var ProvideKairoIdError = class extends Error {
   reason;
+  cause;
   constructor(reason, options = {}) {
     super(DEFAULT_MESSAGES4[reason], { cause: options.cause });
     this.name = "ProvideKairoIdError";
@@ -13878,6 +13887,7 @@ var KairoRegistryBuilder = class {
 // src/router/init/registration/request/errors.ts
 var RegistrationRequestParseError = class extends Error {
   reason;
+  cause;
   constructor(reason, options = {}) {
     super(DEFAULT_MESSAGES5[reason], { cause: options.cause });
     this.name = "RegistrationRequestParseError";
@@ -13963,6 +13973,7 @@ var AddonRegistrationManager = class {
 // src/router/init/registration/response/errors.ts
 var RegistrationResponseError = class extends Error {
   reason;
+  cause;
   constructor(reason, options = {}) {
     super(DEFAULT_MESSAGES6[reason], { cause: options.cause });
     this.name = "RegistrationResponseError";
@@ -14009,7 +14020,7 @@ var RegistrationResponseSchema = Type.Object(
       requiredAddons: Type.Record(Type.String(), Type.String()),
       tags: Type.Array(Type.Union(tagValues.map((tag) => Type.Literal(tag))))
     }),
-    timestamp: Type.Number()
+    timestamp: Type.Integer({ minimum: 0 })
   },
   {
     additionalProperties: false
@@ -14043,13 +14054,13 @@ var RegistrationResponder = class {
 
 // src/router/init/KairoInitializer.ts
 var KairoInitializer = class {
-  constructor(runtime, context, contextMutator) {
+  constructor(runtime, context, contextMutator, random = new SeedRandom()) {
     this.runtime = runtime;
     this.context = context;
     this.contextMutator = contextMutator;
+    this.random = random;
   }
   subscription;
-  random = new SeedRandom();
   idProvider = new KairoIdProvider(this.random);
   registryBuilder = new KairoRegistryBuilder();
   initListener = new KairoInitListener();
@@ -14171,7 +14182,12 @@ var KairoRouter = class {
     this.runtime = resolveRuntime(runtimeOption);
     const { context, mutator } = createKairoContext(properties);
     this.kairoContext = context;
-    const initializer = new KairoInitializer(this.runtime, context, mutator);
+    const initializer = new KairoInitializer(
+      this.runtime,
+      context,
+      mutator,
+      resolveRandom(this.runtime)
+    );
     initializer.setup();
   }
   getKairoContext() {
@@ -14186,6 +14202,12 @@ function resolveRuntime(option) {
     return new MinecraftRuntime();
   }
   return option;
+}
+function resolveRandom(runtime) {
+  if ("createRandom" in runtime && typeof runtime.createRandom === "function") {
+    return runtime.createRandom();
+  }
+  return new SeedRandom();
 }
 
 // src/types/AddonProperties.ts

--- a/src/minecraft/MinecraftRuntime.ts
+++ b/src/minecraft/MinecraftRuntime.ts
@@ -7,9 +7,13 @@ import {
 } from "@minecraft/server";
 import { Disposable } from "../router/types/Disposable";
 import { KairoRuntime } from "../router/types/KairoRuntime";
+import { Random } from "../router/types/Random";
 import { ScoreboardIdRegistry } from "./ScoreboardIdRegistry";
+import { SeedRandom } from "../utils/SeedRandom";
 
 export class MinecraftRuntime implements KairoRuntime {
+    constructor(private readonly options: { randomSeed?: string } = {}) {}
+
     currentTick(): number {
         return system.currentTick;
     }
@@ -48,5 +52,9 @@ export class MinecraftRuntime implements KairoRuntime {
 
     createIdRegistry(objectiveId: string): ScoreboardIdRegistry {
         return new ScoreboardIdRegistry(objectiveId);
+    }
+
+    createRandom(): Random {
+        return new SeedRandom(this.options.randomSeed);
     }
 }

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -1,9 +1,11 @@
 import { MinecraftRuntime } from "../minecraft/MinecraftRuntime";
 import { AddonProperties } from "../types/AddonProperties";
+import { SeedRandom } from "../utils/SeedRandom";
 import { KairoRouterInitError, KairoRouterInitErrorReason } from "./init/errors";
 import { KairoInitializer } from "./init/KairoInitializer";
 import { createKairoContext, KairoContext } from "./KairoContext";
 import { KairoRuntime } from "./types/KairoRuntime";
+import { Random } from "./types/Random";
 
 export type RuntimeOption = KairoRuntime | "minecraft";
 
@@ -27,7 +29,12 @@ export class KairoRouter {
         const { context, mutator } = createKairoContext(properties);
         this.kairoContext = context;
 
-        const initializer = new KairoInitializer(this.runtime, context, mutator);
+        const initializer = new KairoInitializer(
+            this.runtime,
+            context,
+            mutator,
+            resolveRandom(this.runtime),
+        );
         initializer.setup();
     }
 
@@ -44,4 +51,11 @@ function resolveRuntime(option: RuntimeOption): KairoRuntime {
         return new MinecraftRuntime();
     }
     return option;
+}
+
+function resolveRandom(runtime: KairoRuntime): Random {
+    if ("createRandom" in runtime && typeof runtime.createRandom === "function") {
+        return runtime.createRandom();
+    }
+    return new SeedRandom();
 }

--- a/src/router/init/KairoInitializer.ts
+++ b/src/router/init/KairoInitializer.ts
@@ -16,8 +16,6 @@ import { RegistrationResponder } from "./registration/RegistrationResponder";
 export class KairoInitializer implements Disposable {
     private subscription?: Disposable;
 
-    private readonly random: Random = new SeedRandom();
-
     private readonly idProvider = new KairoIdProvider(this.random);
     private readonly registryBuilder = new KairoRegistryBuilder();
 
@@ -31,6 +29,7 @@ export class KairoInitializer implements Disposable {
         private readonly runtime: KairoRuntime,
         private readonly context: KairoContext,
         private readonly contextMutator: KairoContextMutator,
+        private readonly random: Random = new SeedRandom(),
     ) {}
 
     setup(): void {

--- a/src/router/types/KairoRuntime.ts
+++ b/src/router/types/KairoRuntime.ts
@@ -1,5 +1,6 @@
 import { Disposable } from "./Disposable";
 import { IdRegistry } from "./IdRegistry";
+import { Random } from "./Random";
 
 // 環境に依存する機能を抽象化するインターフェース
 export interface KairoRuntime {
@@ -15,4 +16,7 @@ export interface KairoRuntime {
 
     // kairoId の生成に使う
     createIdRegistry(objectiveId: string): IdRegistry;
+
+    // kairoId の乱数生成に使う（未実装の場合はデフォルト実装を使う）
+    createRandom?(): Random;
 }


### PR DESCRIPTION
### Motivation
- Provide a pluggable, testable source of randomness for kairoId generation so IDs can be deterministic or seeded per runtime.
- Allow runtimes to supply their own RNG implementation for better control and testability.
- Ensure discovery/registration timestamps are validated as non-negative integers in schemas.
- Surface underlying error causes when constructing router/init-related errors.

### Description
- Introduced a `Random` interface and `SeedRandom` implementation (wrapping `seedrandom`) and exported typings in `lib/index.d.ts` and `src/utils/SeedRandom.ts`.
- Extended `KairoRuntime` with an optional `createRandom()` method and implemented `createRandom()` in `MinecraftRuntime` to return `SeedRandom` seeded via `MinecraftRuntime` options.
- Threaded the `Random` instance into `KairoInitializer` and `KairoRouter` via a new `resolveRandom` helper so initializer uses the runtime-provided RNG when available; defaulting to `SeedRandom` otherwise.
- Adjusted JSON schemas to use `Type.Integer({ minimum: 0 })` for timestamps and added `cause` parameters to several custom error classes to preserve underlying errors; updated generated `lib` artifacts accordingly.

### Testing
- Ran `npm run build` to compile the TypeScript sources and generate `lib/`, which completed successfully.
- Ran the TypeScript type checker (`tsc`) which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e09b860304833386a053e7a0a84789)