### PR TITLE
Introduce event registry and runtime event binding; emit addon lifecycle events

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -56,6 +56,65 @@ interface RequiredAddons {
     readonly [addonId: string]: string;
 }
 
+interface Disposable {
+    dispose(): void;
+}
+
+declare class InternalEvent<T> implements Subscribable<T> {
+    private listeners;
+    subscribe(fn: (arg: T) => void): Disposable;
+    unsubscribe(fn: (arg: T) => void): void;
+    emit(arg: T): void;
+}
+
+interface Subscribable<T> {
+    subscribe(fn: (arg: T) => void): Disposable;
+    unsubscribe(fn: (arg: T) => void): void;
+}
+
+declare class AddonActivateAfterEvent {
+}
+
+declare class AddonDeactivateBeforeEvent {
+}
+
+interface PlayerJoinAfterEv {
+    readonly playerId: string;
+    readonly playerName: string;
+}
+
+interface KairoEventMap {
+    after: {
+        addonActivate: AddonActivateAfterEvent;
+        playerJoin: PlayerJoinAfterEv;
+    };
+    before: {
+        addonDeactivate: AddonDeactivateBeforeEvent;
+    };
+}
+
+declare class EventRegistry<E extends KairoEventMap> {
+    private after;
+    private before;
+    getAfter<K extends keyof E["after"]>(name: K): InternalEvent<E["after"][K]>;
+    getBefore<K extends keyof E["before"]>(name: K): InternalEvent<E["before"][K]>;
+    emitAfter<K extends keyof E["after"]>(name: K, payload: E["after"][K]): void;
+    emitBefore<K extends keyof E["before"]>(name: K, payload: E["before"][K]): void;
+}
+
+declare class KairoAfterEvents<E extends KairoEventMap> {
+    private registry;
+    constructor(registry: EventRegistry<E>);
+    get addonActivate(): Subscribable<E["after"]["addonActivate"]>;
+    get playerJoin(): Subscribable<E["after"]["playerJoin"]>;
+}
+
+declare class KairoBeforeEvents<E extends KairoEventMap> {
+    private registry;
+    constructor(registry: EventRegistry<E>);
+    get addonDeactivate(): Subscribable<E["before"]["addonDeactivate"]>;
+}
+
 interface KairoRegistry {
     kairoId: string;
     addonId: string;
@@ -85,10 +144,6 @@ declare class KairoContext {
     isRegistered(): boolean;
 }
 
-interface Disposable {
-    dispose(): void;
-}
-
 interface IdRegistry {
     has(id: string): boolean;
     register(id: string): void;
@@ -98,6 +153,11 @@ interface Random {
     next(): number;
 }
 
+type RuntimeEvent = {
+    phase: "after" | "before";
+    name: string;
+    payload: any;
+};
 interface KairoRuntime {
     currentTick(): number;
     send(id: string, message: string): void;
@@ -105,10 +165,13 @@ interface KairoRuntime {
     onReady(handler: () => void): Disposable;
     createIdRegistry(objectiveId: string): IdRegistry;
     createRandom?(): Random;
+    bindEvents?(handler: (ev: RuntimeEvent) => void): Disposable;
 }
 
 type RuntimeOption = KairoRuntime | "minecraft";
 declare class KairoRouter {
+    afterEvents: KairoAfterEvents<KairoEventMap>;
+    beforeEvents: KairoBeforeEvents<KairoEventMap>;
     private constructor();
     init(properties: AddonProperties, options?: {
         runtime?: RuntimeOption;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10908,6 +10908,18 @@ import {
   world as world2
 } from "@minecraft/server";
 
+// src/utils/SeedRandom.ts
+var import_seedrandom = __toESM(require_seedrandom2(), 1);
+var SeedRandom = class {
+  rng;
+  constructor(seed) {
+    this.rng = (0, import_seedrandom.default)(seed);
+  }
+  next() {
+    return this.rng();
+  }
+};
+
 // src/minecraft/ScoreboardIdRegistry.ts
 import { world } from "@minecraft/server";
 var ScoreboardIdRegistry = class {
@@ -10929,16 +10941,14 @@ var ScoreboardIdRegistry = class {
   }
 };
 
-// src/utils/SeedRandom.ts
-var import_seedrandom = __toESM(require_seedrandom2(), 1);
-var SeedRandom = class {
-  rng;
-  constructor(seed) {
-    this.rng = (0, import_seedrandom.default)(seed);
-  }
-  next() {
-    return this.rng();
-  }
+// src/minecraft/minecraftEventBinding.ts
+var minecraftEventBinding = {
+  after: {
+    playerJoin: (world3, handler) => {
+      return world3.afterEvents.playerJoin.subscribe(handler);
+    }
+  },
+  before: {}
 };
 
 // src/minecraft/MinecraftRuntime.ts
@@ -10981,6 +10991,34 @@ var MinecraftRuntime = class {
   createRandom() {
     return new SeedRandom(this.options.randomSeed);
   }
+  bindEvents(handler) {
+    const disposables = [];
+    for (const [name, fn] of Object.entries(minecraftEventBinding.after)) {
+      disposables.push(
+        fn(world2, (payload) => {
+          handler({ phase: "after", name, payload });
+        })
+      );
+    }
+    for (const [name, fn] of Object.entries(minecraftEventBinding.before)) {
+      disposables.push(
+        fn(world2, (payload) => {
+          handler({ phase: "before", name, payload });
+        })
+      );
+    }
+    return {
+      dispose: () => disposables.forEach((d) => d.dispose())
+    };
+  }
+};
+
+// src/router/events/classes/AddonActivateAfterEvent.ts
+var AddonActivateAfterEvent = class {
+};
+
+// src/router/events/classes/AddonDeactivateBeforeEvent.ts
+var AddonDeactivateBeforeEvent = class {
 };
 
 // src/utils/toError.ts
@@ -10990,6 +11028,7 @@ function toError(e) {
 
 // src/router/KairoEventId.ts
 var KairoEventId = /* @__PURE__ */ ((KairoEventId2) => {
+  KairoEventId2["ActivationRequest"] = "kairo:activation_request";
   KairoEventId2["ActivationResponse"] = "kairo:activetion_response";
   return KairoEventId2;
 })(KairoEventId || {});
@@ -13776,52 +13815,112 @@ var ActivationRequestValidator = class {
 var AddonActivationManager = class {
   parser = new ActivationRequestParser();
   validator = new ActivationRequestValidator();
-  constructor() {
-  }
   resolveRequest(message, currentTick, context) {
     const request = this.parser.parse(message, currentTick);
     this.validator.validateRequest(request, currentTick, context.isActive());
     return request;
   }
-  apply(request, currentTick, contextMutator) {
-    if (request.type === "activate") {
-      contextMutator.setActivationState("active", currentTick);
-      return {
-        success: true,
-        action: "activate"
-      };
-    }
-    contextMutator.setActivationState("inactive", currentTick);
-    return {
-      success: true,
-      action: "deactivate"
-    };
-  }
 };
 
 // src/router/activation/ActivationController.ts
 var ActivationController = class {
-  constructor(context, contextMutator) {
+  constructor(context, contextMutator, eventRegistry) {
     this.context = context;
     this.contextMutator = contextMutator;
-    this.activationManager = new AddonActivationManager();
-    this.activationResponder = new ActivationResponder();
+    this.eventRegistry = eventRegistry;
   }
-  activationManager;
-  activationResponder;
+  activationManager = new AddonActivationManager();
+  activationResponder = new ActivationResponder();
   handleActivationRequest = (message, deps) => {
-    const request = this.activationManager.resolveRequest(
-      message,
-      deps.runtime.currentTick(),
-      this.context
-    );
-    const result = this.activationManager.apply(
-      request,
-      deps.runtime.currentTick(),
-      this.contextMutator
-    );
+    const currentTick = deps.runtime.currentTick();
+    const request = this.activationManager.resolveRequest(message, currentTick, this.context);
+    const result = this.apply(request, currentTick);
     this.activationResponder.respond(result, deps.runtime);
   };
+  apply(request, tick) {
+    const next = request.type === "activate" ? "active" : "inactive";
+    if (next === "inactive") {
+      this.eventRegistry.emitBefore("addonDeactivate", new AddonDeactivateBeforeEvent());
+    }
+    this.contextMutator.setActivationState(next, tick);
+    if (next === "active") {
+      this.eventRegistry.emitAfter("addonActivate", new AddonActivateAfterEvent());
+    }
+    return {
+      success: true,
+      action: request.type
+    };
+  }
+};
+
+// src/router/types/InternalEvent.ts
+var InternalEvent = class {
+  listeners = /* @__PURE__ */ new Set();
+  subscribe(fn) {
+    this.listeners.add(fn);
+    return { dispose: () => this.listeners.delete(fn) };
+  }
+  unsubscribe(fn) {
+    this.listeners.delete(fn);
+  }
+  emit(arg) {
+    for (const fn of this.listeners) fn(arg);
+  }
+};
+
+// src/router/events/EventRegistry.ts
+var EventRegistry = class {
+  after = /* @__PURE__ */ new Map();
+  before = /* @__PURE__ */ new Map();
+  getAfter(name) {
+    if (!this.after.has(name)) {
+      this.after.set(name, new InternalEvent());
+    }
+    return this.after.get(name);
+  }
+  getBefore(name) {
+    if (!this.before.has(name)) {
+      this.before.set(name, new InternalEvent());
+    }
+    return this.before.get(name);
+  }
+  emitAfter(name, payload) {
+    this.getAfter(name).emit(payload);
+  }
+  emitBefore(name, payload) {
+    this.getBefore(name).emit(payload);
+  }
+};
+
+// src/router/types/Subscribable.ts
+function asSubscribable(event) {
+  return {
+    subscribe: (fn) => event.subscribe(fn),
+    unsubscribe: (fn) => event.unsubscribe(fn)
+  };
+}
+
+// src/router/events/KairoAfterEvents.ts
+var KairoAfterEvents = class {
+  constructor(registry) {
+    this.registry = registry;
+  }
+  get addonActivate() {
+    return asSubscribable(this.registry.getAfter("addonActivate"));
+  }
+  get playerJoin() {
+    return asSubscribable(this.registry.getAfter("playerJoin"));
+  }
+};
+
+// src/router/events/KairoBeforeEvents.ts
+var KairoBeforeEvents = class {
+  constructor(registry) {
+    this.registry = registry;
+  }
+  get addonDeactivate() {
+    return asSubscribable(this.registry.getBefore("addonDeactivate"));
+  }
 };
 
 // src/router/init/errors.ts
@@ -14596,6 +14695,10 @@ var KairoRouter = class {
   runtime;
   readyState = new ReadyState();
   routerListener;
+  runtimeInjectedEventListener;
+  eventRegistry = new EventRegistry();
+  afterEvents = new KairoAfterEvents(this.eventRegistry);
+  beforeEvents = new KairoBeforeEvents(this.eventRegistry);
   constructor() {
   }
   async init(properties, options) {
@@ -14604,14 +14707,15 @@ var KairoRouter = class {
     }
     const runtimeOption = options?.runtime ?? "minecraft";
     this.runtime = resolveRuntime(runtimeOption);
+    const { context, mutator } = createKairoContext(properties);
+    this.kairoContext = context;
+    this.kairoContextMutator = mutator;
+    this.syncRuntimeInjectedEvents();
     if (!this.readyState.isReady()) {
       this.runtime.onReady(() => {
         this.readyState.markReady();
       });
     }
-    const { context, mutator } = createKairoContext(properties);
-    this.kairoContext = context;
-    this.kairoContextMutator = mutator;
     const initializer = new KairoInitializer(
       this.runtime,
       context,
@@ -14639,7 +14743,8 @@ var KairoRouter = class {
     }
     const activationController = new ActivationController(
       this.kairoContext,
-      this.kairoContextMutator
+      this.kairoContextMutator,
+      this.eventRegistry
     );
     const handlers = this.buildHandlers(activationController);
     const listener = new KairoRouterListener(this.readyState, handlers);
@@ -14647,7 +14752,7 @@ var KairoRouter = class {
   }
   buildHandlers(controller) {
     return {
-      ["kairo:activetion_response" /* ActivationResponse */]: (message) => this.handleActivationRequest(controller, message)
+      ["kairo:activation_request" /* ActivationRequest */]: (message) => this.handleActivationRequest(controller, message)
     };
   }
   handleActivationRequest = (controller, message) => {
@@ -14657,7 +14762,27 @@ var KairoRouter = class {
     controller.handleActivationRequest(message, {
       runtime: this.runtime
     });
+    this.syncRuntimeInjectedEvents();
   };
+  syncRuntimeInjectedEvents() {
+    if (!this.runtime || !this.kairoContext || !this.runtime.bindEvents) {
+      return;
+    }
+    if (this.kairoContext.isActive()) {
+      if (!this.runtimeInjectedEventListener) {
+        this.runtimeInjectedEventListener = this.runtime.bindEvents((ev) => {
+          if (ev.phase === "after") {
+            this.eventRegistry.emitAfter(ev.name, ev.payload);
+          } else {
+            this.eventRegistry.emitBefore(ev.name, ev.payload);
+          }
+        });
+      }
+      return;
+    }
+    this.runtimeInjectedEventListener?.dispose();
+    this.runtimeInjectedEventListener = void 0;
+  }
 };
 function resolveRuntime(option) {
   if (option === "minecraft") {

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -26,6 +26,7 @@ export class KairoRouter {
     private runtime?: KairoRuntime;
     private readyState = new ReadyState();
     private routerListener?: Disposable;
+    private runtimeInjectedEventListener?: Disposable;
 
     private eventRegistry = new EventRegistry<KairoEventMap>();
 
@@ -39,24 +40,16 @@ export class KairoRouter {
         }
         const runtimeOption = options?.runtime ?? "minecraft";
         this.runtime = resolveRuntime(runtimeOption);
-
-        this.runtime.bindEvents?.((ev) => {
-            if (ev.phase === "after") {
-                this.eventRegistry.emitAfter(ev.name as any, ev.payload);
-            } else {
-                this.eventRegistry.emitBefore(ev.name as any, ev.payload);
-            }
-        });
+        const { context, mutator } = createKairoContext(properties);
+        this.kairoContext = context;
+        this.kairoContextMutator = mutator;
+        this.syncRuntimeInjectedEvents();
 
         if (!this.readyState.isReady()) {
             this.runtime.onReady(() => {
                 this.readyState.markReady();
             });
         }
-
-        const { context, mutator } = createKairoContext(properties);
-        this.kairoContext = context;
-        this.kairoContextMutator = mutator;
 
         const initializer = new KairoInitializer(
             this.runtime,
@@ -113,7 +106,31 @@ export class KairoRouter {
         controller.handleActivationRequest(message, {
             runtime: this.runtime,
         });
+
+        this.syncRuntimeInjectedEvents();
     };
+
+    private syncRuntimeInjectedEvents(): void {
+        if (!this.runtime || !this.kairoContext || !this.runtime.bindEvents) {
+            return;
+        }
+
+        if (this.kairoContext.isActive()) {
+            if (!this.runtimeInjectedEventListener) {
+                this.runtimeInjectedEventListener = this.runtime.bindEvents((ev) => {
+                    if (ev.phase === "after") {
+                        this.eventRegistry.emitAfter(ev.name as any, ev.payload);
+                    } else {
+                        this.eventRegistry.emitBefore(ev.name as any, ev.payload);
+                    }
+                });
+            }
+            return;
+        }
+
+        this.runtimeInjectedEventListener?.dispose();
+        this.runtimeInjectedEventListener = undefined;
+    }
 }
 
 function resolveRuntime(option: RuntimeOption): KairoRuntime {


### PR DESCRIPTION
### Motivation
- Provide a generic event system for router and allow runtimes to inject runtime-level events into the router when the addon is active.
- Surface addon lifecycle events (`addonActivate`/`addonDeactivate`) so other code can subscribe to activation changes.
- Enable binding of engine-specific events (e.g. player join) from the runtime into the router's event registry.

### Description
- Add a small event system with `InternalEvent`, `Subscribable`, `Disposable`, `EventRegistry`, `KairoAfterEvents`, and `KairoBeforeEvents` and related types in both `.ts` and compiled `.js`/`.d.ts` outputs.
- Extend `KairoRuntime` with an optional `bindEvents` hook and introduce a `RuntimeEvent` shape used for runtime-to-router event forwarding.
- Add `afterEvents` and `beforeEvents` accessors on `KairoRouter`, and wire an `EventRegistry` into the router instance for centralized event emission and subscription.
- Update `ActivationController` to emit `addonDeactivate` before deactivation and `addonActivate` after activation via the injected `EventRegistry`.
- Implement runtime binding in `MinecraftRuntime` using a `minecraftEventBinding` mapping and a `bindEvents` implementation that forwards engine events into the router as `RuntimeEvent`s, and add `SeedRandom` relocation/usage adjustments.
- Add logic in `KairoRouter` (`syncRuntimeInjectedEvents`) to attach/detach the runtime-provided listener depending on the addon activation state and to re-sync after activation requests.

### Testing
- Ran the TypeScript build and type-checking (`tsc`), which completed successfully.
- Executed the unit test suite (existing router/activation tests), and all tests passed.
- Performed a runtime smoke test with the Minecraft runtime binding to confirm `playerJoin` events and addon activation/deactivation lifecycle events are emitted, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e97ba43ac48333a49155a05eb8320d)