### PR TITLE
Enforce activation-scoped router subscriptions and cleanup

### DIFF
--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -30,7 +30,6 @@ export class KairoRouter {
     private readyState = new ReadyState();
     private routerListener?: Disposable;
     private runtimeInjectedEventListener?: Disposable;
-    private runtimeEventDisposables: Set<Disposable> = new Set();
 
     private eventRegistry!: EventRegistry<KairoEventMap>;
     public afterEvents!: KairoAfterEvents<KairoEventMap>;
@@ -161,11 +160,7 @@ export class KairoRouter {
     }
 
     private detachRuntimeEvents() {
-        for (const d of this.runtimeEventDisposables) {
-            d.dispose();
-        }
-
-        this.runtimeEventDisposables.clear();
+        this.runtimeInjectedEventListener?.dispose();
         this.runtimeInjectedEventListener = undefined;
     }
 

--- a/src/router/activation/ActivationController.ts
+++ b/src/router/activation/ActivationController.ts
@@ -47,6 +47,7 @@ export class ActivationController {
             this.eventRegistry.emitAfter("addonActivate", new AddonActivateAfterEvent());
         } else {
             this.lifecycle.onDeactivate();
+            this.eventRegistry.clearActiveScopedListeners();
         }
 
         return {

--- a/src/router/events/EventRegistry.ts
+++ b/src/router/events/EventRegistry.ts
@@ -9,16 +9,28 @@ export class EventRegistry<E extends KairoEventMap> {
 
     constructor(private context: KairoContext) {}
 
-    getAfter<K extends keyof E["after"]>(name: K): InternalEvent<E["after"][K]> {
+    getAfter<K extends keyof E["after"]>(
+        name: K,
+        options?: {
+            requireActiveOnSubscribe?: boolean;
+            clearOnDeactivate?: boolean;
+        },
+    ): InternalEvent<E["after"][K]> {
         if (!this.after.has(name as string)) {
-            this.after.set(name as string, new InternalEvent(this.context));
+            this.after.set(name as string, new InternalEvent(this.context, options));
         }
         return this.after.get(name as string)!;
     }
 
-    getBefore<K extends keyof E["before"]>(name: K): InternalEvent<E["before"][K]> {
+    getBefore<K extends keyof E["before"]>(
+        name: K,
+        options?: {
+            requireActiveOnSubscribe?: boolean;
+            clearOnDeactivate?: boolean;
+        },
+    ): InternalEvent<E["before"][K]> {
         if (!this.before.has(name as string)) {
-            this.before.set(name as string, new InternalEvent(this.context));
+            this.before.set(name as string, new InternalEvent(this.context, options));
         }
         return this.before.get(name as string)!;
     }
@@ -31,6 +43,19 @@ export class EventRegistry<E extends KairoEventMap> {
     emitBefore<K extends keyof E["before"]>(name: K, payload: E["before"][K]) {
         this.assertActive();
         this.getBefore(name).emit(payload);
+    }
+
+    clearActiveScopedListeners() {
+        for (const event of this.after.values()) {
+            if (event.shouldClearOnDeactivate()) {
+                event.clear();
+            }
+        }
+        for (const event of this.before.values()) {
+            if (event.shouldClearOnDeactivate()) {
+                event.clear();
+            }
+        }
     }
 
     private assertActive() {

--- a/src/router/events/KairoAfterEvents.ts
+++ b/src/router/events/KairoAfterEvents.ts
@@ -6,7 +6,12 @@ export class KairoAfterEvents<E extends KairoEventMap> {
     readonly addonActivate;
     readonly playerJoin;
     constructor(private readonly registry: EventRegistry<E>) {
-        this.addonActivate = asSubscribable(this.registry.getAfter("addonActivate"));
+        this.addonActivate = asSubscribable(
+            this.registry.getAfter("addonActivate", {
+                requireActiveOnSubscribe: false,
+                clearOnDeactivate: false,
+            }),
+        );
         this.playerJoin = asSubscribable(this.registry.getAfter("playerJoin"));
     }
 }

--- a/src/router/events/KairoBeforeEvents.ts
+++ b/src/router/events/KairoBeforeEvents.ts
@@ -5,6 +5,11 @@ import { EventRegistry } from "./EventRegistry";
 export class KairoBeforeEvents<E extends KairoEventMap> {
     readonly addonDeactivate;
     constructor(private registry: EventRegistry<E>) {
-        this.addonDeactivate = asSubscribable(this.registry.getBefore("addonDeactivate"));
+        this.addonDeactivate = asSubscribable(
+            this.registry.getBefore("addonDeactivate", {
+                requireActiveOnSubscribe: false,
+                clearOnDeactivate: false,
+            }),
+        );
     }
 }

--- a/src/router/types/InternalEvent.ts
+++ b/src/router/types/InternalEvent.ts
@@ -6,10 +6,18 @@ import { Subscribable } from "./Subscribable";
 export class InternalEvent<T> implements Subscribable<T> {
     private listeners = new Set<(arg: T) => void>();
 
-    constructor(private readonly context: KairoContext) {}
+    constructor(
+        private readonly context: KairoContext,
+        private readonly options: {
+            requireActiveOnSubscribe?: boolean;
+            clearOnDeactivate?: boolean;
+        } = {},
+    ) {}
 
     subscribe(fn: (arg: T) => void): Disposable {
-        this.assertActive();
+        if (this.options.requireActiveOnSubscribe ?? true) {
+            this.assertActive();
+        }
 
         this.listeners.add(fn);
 
@@ -24,6 +32,14 @@ export class InternalEvent<T> implements Subscribable<T> {
 
     emit(arg: T): void {
         for (const fn of this.listeners) fn(arg);
+    }
+
+    clear(): void {
+        this.listeners.clear();
+    }
+
+    shouldClearOnDeactivate(): boolean {
+        return this.options.clearOnDeactivate ?? true;
     }
 
     private assertActive() {


### PR DESCRIPTION
### Motivation
- Ensure lifecycle events (`addonActivate`/`addonDeactivate`) can be subscribed regardless of activation state while keeping runtime-dependent events (e.g. `playerJoin`) subscribeable only when active.
- Automatically release active-scoped subscriptions and scheduler/runtime bindings when the addon deactivates to avoid leaks and invalid listeners.

### Description
- Added per-event policies to `InternalEvent` via an `options` parameter supporting `requireActiveOnSubscribe` and `clearOnDeactivate` and exposed `clear()` / `shouldClearOnDeactivate()` methods.
- Extended `EventRegistry` to pass per-event options to `InternalEvent` and added `clearActiveScopedListeners()` to clear listeners that are scoped to active state.
- Configured lifecycle events in `KairoAfterEvents` and `KairoBeforeEvents` so that `addonActivate` and `addonDeactivate` use `{ requireActiveOnSubscribe: false, clearOnDeactivate: false }` while events like `playerJoin` keep default (active-only) behavior.
- Call `clearActiveScopedListeners()` on deactivate from `ActivationController`, and fixed `KairoRouter.detachRuntimeEvents()` to actually dispose the runtime-injected event listener.

### Testing
- Ran TypeScript check with `pnpm -s tsc --noEmit` which executed but failed; failures are in unrelated areas (`src/____addons/*`, `src/____utils/*`) due to missing modules / lib settings and are not caused by the changes in this PR.
- No unit tests were added or run as part of this change; manual inspection and local type-checking indicate the new API and lifecycle cleanup are wired as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9d924cdcc833389ee3016ec9b3e75)