### PR TITLE
Add lifecycle-aware event registry, typed runtime/event bindings, and context types

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -60,6 +60,34 @@ interface Disposable {
     dispose(): void;
 }
 
+interface KairoRegistry {
+    kairoId: string;
+    addonId: string;
+    name: string;
+    description: string;
+    version: SemVer;
+    metadata: {
+        authors: string[];
+        url?: string;
+        license?: string;
+    };
+    requiredAddons: {
+        [addonId: string]: string;
+    };
+    tags: SupportedTag[];
+}
+
+declare class KairoContext {
+    private constructor(
+);
+    get addonProperties(): AddonProperties;
+    get kairoId(): string;
+    get kairoRegistry(): KairoRegistry;
+    get activationState(): "active" | "inactive";
+    isActive(): boolean;
+    isRegistered(): boolean;
+}
+
 interface Subscribable<T> {
     subscribe(fn: (arg: T) => void): Disposable;
     unsubscribe(fn: (arg: T) => void): void;
@@ -101,34 +129,6 @@ declare class KairoBeforeEvents<E extends KairoEventMap> {
     private constructor();
 }
 
-interface KairoRegistry {
-    kairoId: string;
-    addonId: string;
-    name: string;
-    description: string;
-    version: SemVer;
-    metadata: {
-        authors: string[];
-        url?: string;
-        license?: string;
-    };
-    requiredAddons: {
-        [addonId: string]: string;
-    };
-    tags: SupportedTag[];
-}
-
-declare class KairoContext {
-    private constructor(
-);
-    get addonProperties(): AddonProperties;
-    get kairoId(): string;
-    get kairoRegistry(): KairoRegistry;
-    get activationState(): "active" | "inactive";
-    isActive(): boolean;
-    isRegistered(): boolean;
-}
-
 interface IdRegistry {
     has(id: string): boolean;
     register(id: string): void;
@@ -144,23 +144,33 @@ interface Random {
     next(): number;
 }
 
-type RuntimeEvent = {
-    phase: "after" | "before";
-    name: string;
-    payload: any;
-};
-interface KairoRuntime {
+type AfterRuntimeEvent<E extends KairoEventMap> = {
+    [K in keyof E["after"]]: {
+        phase: "after";
+        name: K;
+        payload: E["after"][K];
+    };
+}[keyof E["after"]];
+type BeforeRuntimeEvent<E extends KairoEventMap> = {
+    [K in keyof E["before"]]: {
+        phase: "before";
+        name: K;
+        payload: E["before"][K];
+    };
+}[keyof E["before"]];
+type RuntimeEvent<E extends KairoEventMap = KairoEventMap> = AfterRuntimeEvent<E> | BeforeRuntimeEvent<E>;
+interface KairoRuntime<E extends KairoEventMap = KairoEventMap> {
     currentTick(): number;
     send(id: string, message: string): void;
     receive(handler: (id: string, message: string) => void): Disposable;
     onReady(handler: () => void): Disposable;
     createIdRegistry(objectiveId: string): IdRegistry;
     createRandom?(): Random;
-    bindEvents(handler: (ev: RuntimeEvent) => void): Disposable;
+    bindEvents(handler: (ev: RuntimeEvent<E>) => void): Disposable;
     scheduler: KairoSchedulerRuntime;
 }
 
-type RuntimeOption = KairoRuntime | "minecraft";
+type RuntimeOption = KairoRuntime<KairoEventMap> | "minecraft";
 declare class KairoRouter {
     afterEvents: KairoAfterEvents<KairoEventMap>;
     beforeEvents: KairoBeforeEvents<KairoEventMap>;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10944,11 +10944,24 @@ var ScoreboardIdRegistry = class {
 // src/minecraft/minecraftEventBinding.ts
 var minecraftEventBinding = {
   after: {
+    addonActivate: (_world, _handler) => {
+      return {
+        dispose: () => {
+        }
+      };
+    },
     playerJoin: (world3, handler) => {
       return world3.afterEvents.playerJoin.subscribe(handler);
     }
   },
-  before: {}
+  before: {
+    addonDeactivate: (_world, _handler) => {
+      return {
+        dispose: () => {
+        }
+      };
+    }
+  }
 };
 
 // src/minecraft/MinecraftRuntime.ts
@@ -13854,6 +13867,7 @@ var ActivationController = class {
       this.eventRegistry.emitAfter("addonActivate", new AddonActivateAfterEvent());
     } else {
       this.lifecycle.onDeactivate();
+      this.eventRegistry.clearActiveScopedListeners();
     }
     return {
       success: true,
@@ -13878,10 +13892,19 @@ var DEFAULT_MESSAGES4 = {
 
 // src/router/types/InternalEvent.ts
 var InternalEvent = class {
+  constructor(context, options = {}) {
+    this.context = context;
+    this.options = options;
+  }
   listeners = /* @__PURE__ */ new Set();
   subscribe(fn) {
+    if (this.options.requireActiveOnSubscribe ?? true) {
+      this.assertActive();
+    }
     this.listeners.add(fn);
-    return { dispose: () => this.listeners.delete(fn) };
+    return {
+      dispose: () => this.listeners.delete(fn)
+    };
   }
   unsubscribe(fn) {
     this.listeners.delete(fn);
@@ -13889,29 +13912,62 @@ var InternalEvent = class {
   emit(arg) {
     for (const fn of this.listeners) fn(arg);
   }
+  clear() {
+    this.listeners.clear();
+  }
+  shouldClearOnDeactivate() {
+    return this.options.clearOnDeactivate ?? true;
+  }
+  assertActive() {
+    if (!this.context.isActive()) {
+      throw new KairoRouterError("Inactive" /* Inactive */);
+    }
+  }
 };
 
 // src/router/events/EventRegistry.ts
 var EventRegistry = class {
+  constructor(context) {
+    this.context = context;
+  }
   after = /* @__PURE__ */ new Map();
   before = /* @__PURE__ */ new Map();
-  getAfter(name) {
+  getAfter(name, options) {
     if (!this.after.has(name)) {
-      this.after.set(name, new InternalEvent());
+      this.after.set(name, new InternalEvent(this.context, options));
     }
     return this.after.get(name);
   }
-  getBefore(name) {
+  getBefore(name, options) {
     if (!this.before.has(name)) {
-      this.before.set(name, new InternalEvent());
+      this.before.set(name, new InternalEvent(this.context, options));
     }
     return this.before.get(name);
   }
   emitAfter(name, payload) {
+    this.assertActive();
     this.getAfter(name).emit(payload);
   }
   emitBefore(name, payload) {
+    this.assertActive();
     this.getBefore(name).emit(payload);
+  }
+  clearActiveScopedListeners() {
+    for (const event of this.after.values()) {
+      if (event.shouldClearOnDeactivate()) {
+        event.clear();
+      }
+    }
+    for (const event of this.before.values()) {
+      if (event.shouldClearOnDeactivate()) {
+        event.clear();
+      }
+    }
+  }
+  assertActive() {
+    if (!this.context.isActive()) {
+      throw new KairoRouterError("Inactive" /* Inactive */);
+    }
   }
 };
 
@@ -13927,7 +13983,12 @@ function asSubscribable(event) {
 var KairoAfterEvents = class {
   constructor(registry) {
     this.registry = registry;
-    this.addonActivate = asSubscribable(this.registry.getAfter("addonActivate"));
+    this.addonActivate = asSubscribable(
+      this.registry.getAfter("addonActivate", {
+        requireActiveOnSubscribe: false,
+        clearOnDeactivate: false
+      })
+    );
     this.playerJoin = asSubscribable(this.registry.getAfter("playerJoin"));
   }
   addonActivate;
@@ -13938,7 +13999,12 @@ var KairoAfterEvents = class {
 var KairoBeforeEvents = class {
   constructor(registry) {
     this.registry = registry;
-    this.addonDeactivate = asSubscribable(this.registry.getBefore("addonDeactivate"));
+    this.addonDeactivate = asSubscribable(
+      this.registry.getBefore("addonDeactivate", {
+        requireActiveOnSubscribe: false,
+        clearOnDeactivate: false
+      })
+    );
   }
   addonDeactivate;
 };
@@ -14750,9 +14816,9 @@ var KairoRouter = class {
   readyState = new ReadyState();
   routerListener;
   runtimeInjectedEventListener;
-  eventRegistry = new EventRegistry();
-  afterEvents = new KairoAfterEvents(this.eventRegistry);
-  beforeEvents = new KairoBeforeEvents(this.eventRegistry);
+  eventRegistry;
+  afterEvents;
+  beforeEvents;
   init(properties, options) {
     if (this.kairoContext) {
       throw new KairoRouterInitError("AlreadyInitialized" /* AlreadyInitialized */);
@@ -14763,6 +14829,9 @@ var KairoRouter = class {
     const { context, mutator } = createKairoContext(properties);
     this.kairoContext = context;
     this.kairoContextMutator = mutator;
+    this.eventRegistry = new EventRegistry(this.kairoContext);
+    this.afterEvents = new KairoAfterEvents(this.eventRegistry);
+    this.beforeEvents = new KairoBeforeEvents(this.eventRegistry);
     if (!this.readyState.isReady()) {
       this.runtime.onReady(() => {
         this.readyState.markReady();
@@ -14839,11 +14908,10 @@ var KairoRouter = class {
     });
   }
   attachRuntimeEvents() {
-    if (!this.runtime) {
-      throw new KairoRouterInitError("NotInitialized" /* NotInitialized */);
-    }
+    if (!this.runtime) throw new Error("not init");
     if (this.runtimeInjectedEventListener) return;
     this.runtimeInjectedEventListener = this.runtime.bindEvents((ev) => {
+      if (!this.kairoContext?.isActive()) return;
       if (ev.phase === "after") {
         this.eventRegistry.emitAfter(ev.name, ev.payload);
       } else {

--- a/src/minecraft/MinecraftRuntime.ts
+++ b/src/minecraft/MinecraftRuntime.ts
@@ -8,12 +8,13 @@ import {
 import { Disposable } from "../router/types/Disposable";
 import { KairoRuntime, RuntimeEvent } from "../router/types/KairoRuntime";
 import { KairoSchedulerRuntime } from "../router/types/KairoSchedulerRuntime";
+import { KairoEventMap } from "../router/types/KairoEventMap";
 import { Random } from "../router/types/Random";
 import { SeedRandom } from "../utils/SeedRandom";
 import { ScoreboardIdRegistry } from "./ScoreboardIdRegistry";
 import { minecraftEventBinding } from "./minecraftEventBinding";
 
-export class MinecraftRuntime implements KairoRuntime {
+export class MinecraftRuntime implements KairoRuntime<KairoEventMap> {
     constructor(private readonly options: { randomSeed?: string } = {}) {}
 
     currentTick(): number {
@@ -60,13 +61,13 @@ export class MinecraftRuntime implements KairoRuntime {
         return new SeedRandom(this.options.randomSeed);
     }
 
-    bindEvents(handler: (ev: RuntimeEvent) => void): Disposable {
+    bindEvents(handler: (ev: RuntimeEvent<KairoEventMap>) => void): Disposable {
         const disposables: Disposable[] = [];
 
         for (const [name, fn] of Object.entries(minecraftEventBinding.after)) {
             disposables.push(
                 fn(world, (payload: any) => {
-                    handler({ phase: "after", name, payload });
+                    handler({ phase: "after", name: name as keyof KairoEventMap["after"], payload });
                 }),
             );
         }
@@ -74,7 +75,7 @@ export class MinecraftRuntime implements KairoRuntime {
         for (const [name, fn] of Object.entries(minecraftEventBinding.before)) {
             disposables.push(
                 fn(world, (payload: any) => {
-                    handler({ phase: "before", name, payload });
+                    handler({ phase: "before", name: name as keyof KairoEventMap["before"], payload });
                 }),
             );
         }

--- a/src/minecraft/minecraftEventBinding.ts
+++ b/src/minecraft/minecraftEventBinding.ts
@@ -1,11 +1,23 @@
 import { EventBindingSpec } from "../router/types/EventBindingSpec";
+import { KairoEventMap } from "../router/types/KairoEventMap";
 
-export const minecraftEventBinding: EventBindingSpec = {
+export const minecraftEventBinding: EventBindingSpec<KairoEventMap> = {
     after: {
+        addonActivate: (_world, _handler) => {
+            return {
+                dispose: () => {},
+            };
+        },
         playerJoin: (world, handler) => {
             return world.afterEvents.playerJoin.subscribe(handler);
-        }
+        },
     },
 
-    before: {},
+    before: {
+        addonDeactivate: (_world, _handler) => {
+            return {
+                dispose: () => {},
+            };
+        },
+    },
 };

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -18,13 +18,13 @@ import { KairoEventMap } from "./types/KairoEventMap";
 import { KairoRuntime } from "./types/KairoRuntime";
 import { Random } from "./types/Random";
 
-export type RuntimeOption = KairoRuntime | "minecraft";
+export type RuntimeOption = KairoRuntime<KairoEventMap> | "minecraft";
 
 // kjs-router-ch 0001
 export class KairoRouter {
     private kairoContext?: KairoContext;
     private kairoContextMutator?: KairoContextMutator;
-    private runtime?: KairoRuntime;
+    private runtime?: KairoRuntime<KairoEventMap>;
     private scheduler?: KairoScheduler;
     private activationStartedTick?: number;
     private readyState = new ReadyState();
@@ -152,9 +152,9 @@ export class KairoRouter {
             if (!this.kairoContext?.isActive()) return;
 
             if (ev.phase === "after") {
-                this.eventRegistry.emitAfter(ev.name as any, ev.payload);
+                this.eventRegistry.emitAfter(ev.name, ev.payload);
             } else {
-                this.eventRegistry.emitBefore(ev.name as any, ev.payload);
+                this.eventRegistry.emitBefore(ev.name, ev.payload);
             }
         });
     }
@@ -175,14 +175,14 @@ export class KairoRouter {
     }
 }
 
-function resolveRuntime(option: RuntimeOption): KairoRuntime {
+function resolveRuntime(option: RuntimeOption): KairoRuntime<KairoEventMap> {
     if (option === "minecraft") {
         return new MinecraftRuntime();
     }
     return option;
 }
 
-function resolveRandom(runtime: KairoRuntime): Random {
+function resolveRandom(runtime: KairoRuntime<KairoEventMap>): Random {
     if ("createRandom" in runtime && typeof runtime.createRandom === "function") {
         return runtime.createRandom();
     }

--- a/src/router/types/EventBindingSpec.ts
+++ b/src/router/types/EventBindingSpec.ts
@@ -1,6 +1,11 @@
 import { Disposable } from "./Disposable";
+import { KairoEventMap } from "./KairoEventMap";
 
-export type EventBindingSpec = {
-    after: Record<string, (world: any, handler: (payload: any) => void) => Disposable>;
-    before: Record<string, (world: any, handler: (payload: any) => void) => Disposable>;
+export type EventBindingSpec<E extends KairoEventMap = KairoEventMap> = {
+    after: {
+        [K in keyof E["after"]]: (world: any, handler: (payload: E["after"][K]) => void) => Disposable;
+    };
+    before: {
+        [K in keyof E["before"]]: (world: any, handler: (payload: E["before"][K]) => void) => Disposable;
+    };
 };

--- a/src/router/types/KairoRuntime.ts
+++ b/src/router/types/KairoRuntime.ts
@@ -1,16 +1,31 @@
 import { Disposable } from "./Disposable";
 import { IdRegistry } from "./IdRegistry";
+import { KairoEventMap } from "./KairoEventMap";
 import { KairoSchedulerRuntime } from "./KairoSchedulerRuntime";
 import { Random } from "./Random";
 
-export type RuntimeEvent = {
-    phase: "after" | "before";
-    name: string;
-    payload: any;
-};
+type AfterRuntimeEvent<E extends KairoEventMap> = {
+    [K in keyof E["after"]]: {
+        phase: "after";
+        name: K;
+        payload: E["after"][K];
+    };
+}[keyof E["after"]];
+
+type BeforeRuntimeEvent<E extends KairoEventMap> = {
+    [K in keyof E["before"]]: {
+        phase: "before";
+        name: K;
+        payload: E["before"][K];
+    };
+}[keyof E["before"]];
+
+export type RuntimeEvent<E extends KairoEventMap = KairoEventMap> =
+    | AfterRuntimeEvent<E>
+    | BeforeRuntimeEvent<E>;
 
 // 環境に依存する機能を抽象化するインターフェース
-export interface KairoRuntime {
+export interface KairoRuntime<E extends KairoEventMap = KairoEventMap> {
     // TimeStamp の検証などに使う
     currentTick(): number;
 
@@ -28,7 +43,7 @@ export interface KairoRuntime {
     createRandom?(): Random;
 
     // 環境固有のイベント
-    bindEvents(handler: (ev: RuntimeEvent) => void): Disposable;
+    bindEvents(handler: (ev: RuntimeEvent<E>) => void): Disposable;
 
     // runInterval, runTimeout の実装
     scheduler: KairoSchedulerRuntime;


### PR DESCRIPTION
### Motivation
- Introduce stronger typing for runtime events and event bindings and add lifecycle-aware behavior so events behave correctly across addon activation/deactivation.
- Expose additional context types (`KairoContext`, `KairoRegistry`) for consumers and emit lifecycle events (`addonActivate`/`addonDeactivate`) from the Minecraft bindings.

### Description
- Added `KairoRegistry` and `KairoContext` type declarations to public types and adjusted exports in `lib/index.*`.
- Reworked runtime/event typing to be generic over `KairoEventMap` by introducing `RuntimeEvent<E>`, generic `KairoRuntime<E>`, and typed `EventBindingSpec<E>` so event names and payloads are strongly typed end-to-end.
- Implemented lifecycle-aware `InternalEvent` and `EventRegistry` behavior including `assertActive`, `clearActiveScopedListeners`, configurable subscribe/clear options, and automatic clearing of scoped listeners on deactivate in `ActivationController`.
- Updated `KairoAfterEvents` and `KairoBeforeEvents` to make `addonActivate`/`addonDeactivate` subscribes allowed when inactive and to opt them out of being cleared on deactivation, and added no-op bindings for those events in `minecraftEventBinding` and `MinecraftRuntime.bindEvents` adaptations.
- Updated `KairoRouter` to construct `EventRegistry` with the `KairoContext`, wire the typed `afterEvents`/`beforeEvents`, guard event emission by context active state, and refine runtime resolution and random resolution signatures.

### Testing
- Ran TypeScript build (`npm run build`) to produce compiled `lib/` artifacts and type-checking, and the build completed successfully.
- No additional automated unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eac7b33ae0833397a5468e1782a586)