### PR TITLE
Use scheduler-driven activation tick counter in KairoRouter

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14812,7 +14812,8 @@ var KairoRouter = class {
   kairoContextMutator;
   runtime;
   scheduler;
-  activationStartedTick;
+  activationCurrentTick = 0;
+  activationTickIntervalId;
   readyState = new ReadyState();
   routerListener;
   runtimeInjectedEventListener;
@@ -14863,10 +14864,10 @@ var KairoRouter = class {
     if (!this.runtime) {
       throw new KairoRouterInitError("NotInitialized" /* NotInitialized */);
     }
-    if (this.activationStartedTick === void 0) {
+    if (this.activationTickIntervalId === void 0) {
       return 0;
     }
-    return this.runtime.currentTick() - this.activationStartedTick;
+    return this.activationCurrentTick;
   }
   startRouterListener() {
     if (!this.runtime || !this.kairoContext || !this.kairoContextMutator) {
@@ -14881,10 +14882,12 @@ var KairoRouter = class {
       this.eventRegistry,
       {
         onActivate: () => {
+          this.startActivationTickCounter();
           this.attachRuntimeEvents();
           this.scheduler?.setActive(true);
         },
         onDeactivate: () => {
+          this.stopActivationTickCounter();
           this.detachRuntimeEvents();
           this.scheduler?.setActive(false);
         }
@@ -14922,6 +14925,24 @@ var KairoRouter = class {
   detachRuntimeEvents() {
     this.runtimeInjectedEventListener?.dispose();
     this.runtimeInjectedEventListener = void 0;
+  }
+  startActivationTickCounter() {
+    if (!this.runtime) {
+      throw new KairoRouterInitError("NotInitialized" /* NotInitialized */);
+    }
+    this.stopActivationTickCounter();
+    this.activationCurrentTick = 0;
+    this.activationTickIntervalId = this.runtime.scheduler.runInterval(() => {
+      this.activationCurrentTick++;
+    }, 1);
+  }
+  stopActivationTickCounter() {
+    if (!this.runtime) return;
+    if (this.activationTickIntervalId !== void 0) {
+      this.runtime.scheduler.clearRun(this.activationTickIntervalId);
+      this.activationTickIntervalId = void 0;
+    }
+    this.activationCurrentTick = 0;
   }
   assertRunnable() {
     if (!this.kairoContext || !this.runtime || !this.scheduler) {

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -26,7 +26,8 @@ export class KairoRouter {
     private kairoContextMutator?: KairoContextMutator;
     private runtime?: KairoRuntime<KairoEventMap>;
     private scheduler?: KairoScheduler;
-    private activationStartedTick?: number;
+    private activationCurrentTick = 0;
+    private activationTickIntervalId?: number;
     private readyState = new ReadyState();
     private routerListener?: Disposable;
     private runtimeInjectedEventListener?: Disposable;
@@ -89,10 +90,10 @@ export class KairoRouter {
         if (!this.runtime) {
             throw new KairoRouterInitError(KairoRouterInitErrorReason.NotInitialized);
         }
-        if (this.activationStartedTick === undefined) {
+        if (this.activationTickIntervalId === undefined) {
             return 0;
         }
-        return this.runtime.currentTick() - this.activationStartedTick;
+        return this.activationCurrentTick;
     }
 
     private startRouterListener(): void {
@@ -110,10 +111,12 @@ export class KairoRouter {
             this.eventRegistry,
             {
                 onActivate: () => {
+                    this.startActivationTickCounter();
                     this.attachRuntimeEvents();
                     this.scheduler?.setActive(true);
                 },
                 onDeactivate: () => {
+                    this.stopActivationTickCounter();
                     this.detachRuntimeEvents();
                     this.scheduler?.setActive(false);
                 },
@@ -162,6 +165,29 @@ export class KairoRouter {
     private detachRuntimeEvents() {
         this.runtimeInjectedEventListener?.dispose();
         this.runtimeInjectedEventListener = undefined;
+    }
+
+    private startActivationTickCounter(): void {
+        if (!this.runtime) {
+            throw new KairoRouterInitError(KairoRouterInitErrorReason.NotInitialized);
+        }
+
+        this.stopActivationTickCounter();
+        this.activationCurrentTick = 0;
+        this.activationTickIntervalId = this.runtime.scheduler.runInterval(() => {
+            this.activationCurrentTick++;
+        }, 1);
+    }
+
+    private stopActivationTickCounter(): void {
+        if (!this.runtime) return;
+
+        if (this.activationTickIntervalId !== undefined) {
+            this.runtime.scheduler.clearRun(this.activationTickIntervalId);
+            this.activationTickIntervalId = undefined;
+        }
+
+        this.activationCurrentTick = 0;
     }
 
     private assertRunnable(): void {


### PR DESCRIPTION
### Motivation
- Replace the previous `activationStartedTick`/`runtime.currentTick()` subtraction approach with an internal tick counter to more reliably track ticks while the router is active. 
- Ensure the activation tick count is only advanced while the router is active and reset on deactivation. 
- Avoid relying on direct `runtime.currentTick()` arithmetic which can be brittle across runtime implementations.

### Description
- Replaces `activationStartedTick` with `activationCurrentTick` and `activationTickIntervalId` and updates the `currentTick` getter to return the internal counter. 
- Adds `startActivationTickCounter` and `stopActivationTickCounter` which use `this.runtime.scheduler.runInterval` to increment `activationCurrentTick` and `clearRun` to stop it. 
- Hooks the new counter into the activation lifecycle by calling `startActivationTickCounter()` on activate and `stopActivationTickCounter()` on deactivate. 
- Updates both TypeScript (`src/router/KairoRouter.ts`) and compiled JS (`lib/index.js`) to reflect the changes.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacb21a8008333addb60b4ee781bcd)