### PR TITLE
feat(router): add clearRun API on KairoRouter

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -182,6 +182,7 @@ declare class KairoRouter {
     getKairoContext(): KairoContext;
     runInterval(callback: () => void, tickInterval?: number): number;
     runTimeout(callback: () => void, tickDelay?: number): number;
+    clearRun(runId: number): void;
     get currentTick(): number;
     private constructor();
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -14860,6 +14860,10 @@ var KairoRouter = class {
     this.assertRunnable();
     return this.scheduler.runTimeout(callback, tickDelay);
   }
+  clearRun(runId) {
+    this.assertRunnable();
+    this.scheduler.clearRun(runId);
+  }
   get currentTick() {
     if (!this.runtime) {
       throw new KairoRouterInitError("NotInitialized" /* NotInitialized */);

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -86,6 +86,11 @@ export class KairoRouter {
         return this.scheduler!.runTimeout(callback, tickDelay);
     }
 
+    clearRun(runId: number): void {
+        this.assertRunnable();
+        this.scheduler!.clearRun(runId);
+    }
+
     get currentTick(): number {
         if (!this.runtime) {
             throw new KairoRouterInitError(KairoRouterInitErrorReason.NotInitialized);


### PR DESCRIPTION
### Motivation
- The public `KairoRouter` API did not expose a way to cancel scheduled runs created via `runInterval`/`runTimeout`, so callers couldn't permanently remove scheduled tasks from the router surface.
- Exposing `clearRun` allows callers to cancel runs directly from `router` and rely on the existing scheduler cleanup semantics.

### Description
- Added a new public method `clearRun(runId: number)` to `KairoRouter` that calls the underlying scheduler via `this.scheduler!.clearRun(runId)` and validates runtime state with `this.assertRunnable()`.
- Updated distributed artifacts so the new API is available in `lib/index.js` and `lib/index.d.ts`.
- No changes to scheduler internals were required because the scheduler already removes tracked tasks when `clearRun` is invoked.

### Testing
- Ran the build pipeline with `pnpm run build && pnpm run postbuild` which completed successfully.
- Verified the generated outputs contain the new API by searching for `clearRun(runId)` in `src/router/KairoRouter.ts`, `lib/index.js`, and `lib/index.d.ts`, all of which were updated successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eacfded2b8833395aea0d8777d5d38)