### PR TITLE
feat: expose router.systemInfo getter

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -179,7 +179,7 @@ declare class KairoRouter {
     init(properties: AddonProperties, options?: {
         runtime?: RuntimeOption;
     }): void;
-    getKairoContext(): KairoContext;
+    get systemInfo(): KairoContext;
     runInterval(callback: () => void, tickInterval?: number): number;
     runTimeout(callback: () => void, tickDelay?: number): number;
     clearRun(runId: number): void;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14848,7 +14848,7 @@ var KairoRouter = class {
     );
     initializer.setup();
   }
-  getKairoContext() {
+  get systemInfo() {
     this.assertRunnable();
     return this.kairoContext;
   }

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -71,7 +71,7 @@ export class KairoRouter {
         initializer.setup();
     }
 
-    getKairoContext(): KairoContext {
+    get systemInfo(): KairoContext {
         this.assertRunnable();
         return this.kairoContext!;
     }


### PR DESCRIPTION
### Motivation
- Replace `getKairoContext()` with a property getter `systemInfo` so callers can access the current `KairoContext` as `router.systemInfo` (e.g. `router.systemInfo.kairoId`) and treat it as a read-only system info view.

### Description
- Renamed `getKairoContext()` to `get systemInfo()` in `src/router/KairoRouter.ts` and updated the compiled outputs `lib/index.js` and type declarations `lib/index.d.ts` to expose `get systemInfo(): KairoContext`.

### Testing
- Ran `pnpm run build` (TS build and d.ts postprocessing), and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ead3c9295083339561ed46c488c009)