### PR TITLE
Add waitForWorldLoad API and ReadyState.wait to router

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -137,6 +137,7 @@ declare class KairoRouter {
     get systemInfo(): KairoContext;
     clearRun(runId: number): void;
     init(properties: AddonProperties): void;
+    waitForWorldLoad(): Promise<void>;
     register(targetId: string, eventId: string, returnTypes: string, ...argsTypes: string[]): void;
     request<T = unknown>(targetId: string, eventId: string, ...args: unknown[]): Promise<void>;
     runInterval(callback: () => void, tickInterval?: number): number;

--- a/lib/index.js
+++ b/lib/index.js
@@ -14794,6 +14794,14 @@ var ReadyState = class {
       }
     };
   }
+  wait() {
+    if (this.ready) {
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.onReady(resolve);
+    });
+  }
 };
 
 // src/router/KairoRouter.ts
@@ -14807,6 +14815,7 @@ var KairoRouter = class {
   readyState = new ReadyState();
   routerListener;
   runtimeInjectedEventListener;
+  worldLoadListener;
   eventRegistry = new EventRegistry(() => {
     if (!this.kairoContext) return false;
     return this.kairoContext.isActive();
@@ -14839,11 +14848,7 @@ var KairoRouter = class {
     const { context, mutator } = createKairoContext(properties);
     this.kairoContext = context;
     this.kairoContextMutator = mutator;
-    if (!this.readyState.isReady()) {
-      this.runtime.onReady(() => {
-        this.readyState.markReady();
-      });
-    }
+    this.startWorldLoadListener(this.runtime);
     const initializer = new KairoInitializer(
       this.runtime,
       context,
@@ -14853,6 +14858,10 @@ var KairoRouter = class {
       () => this.startRouterListener()
     );
     initializer.setup();
+  }
+  waitForWorldLoad() {
+    this.startWorldLoadListener(this.runtime ?? new KairoRuntime());
+    return this.readyState.wait();
   }
   register(targetId, eventId, returnTypes, ...argsTypes) {
   }
@@ -14867,6 +14876,14 @@ var KairoRouter = class {
     return this.scheduler.runTimeout(callback, tickDelay);
   }
   send(targetId, eventId, ...args) {
+  }
+  startWorldLoadListener(runtime) {
+    if (this.readyState.isReady() || this.worldLoadListener) return;
+    this.worldLoadListener = runtime.onReady(() => {
+      this.worldLoadListener?.dispose();
+      this.worldLoadListener = void 0;
+      this.readyState.markReady();
+    });
   }
   startRouterListener() {
     if (!this.runtime || !this.kairoContext || !this.kairoContextMutator) {

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -28,6 +28,7 @@ export class KairoRouter {
     private readyState = new ReadyState();
     private routerListener?: Disposable;
     private runtimeInjectedEventListener?: Disposable;
+    private worldLoadListener?: Disposable;
 
     private eventRegistry = new EventRegistry(() => {
         if (!this.kairoContext) return false;
@@ -68,11 +69,7 @@ export class KairoRouter {
         this.kairoContext = context;
         this.kairoContextMutator = mutator;
 
-        if (!this.readyState.isReady()) {
-            this.runtime.onReady(() => {
-                this.readyState.markReady();
-            });
-        }
+        this.startWorldLoadListener(this.runtime);
 
         const initializer = new KairoInitializer(
             this.runtime,
@@ -84,6 +81,11 @@ export class KairoRouter {
         );
 
         initializer.setup();
+    }
+
+    waitForWorldLoad(): Promise<void> {
+        this.startWorldLoadListener(this.runtime ?? new KairoRuntime());
+        return this.readyState.wait();
     }
 
     register(
@@ -110,6 +112,16 @@ export class KairoRouter {
     }
 
     send(targetId: string, eventId: string, ...args: unknown[]): void {}
+
+    private startWorldLoadListener(runtime: KairoRuntime<KairoEventMap>): void {
+        if (this.readyState.isReady() || this.worldLoadListener) return;
+
+        this.worldLoadListener = runtime.onReady(() => {
+            this.worldLoadListener?.dispose();
+            this.worldLoadListener = undefined;
+            this.readyState.markReady();
+        });
+    }
 
     private startRouterListener(): void {
         if (!this.runtime || !this.kairoContext || !this.kairoContextMutator) {

--- a/src/router/ReadyState.ts
+++ b/src/router/ReadyState.ts
@@ -30,4 +30,14 @@ export class ReadyState {
             },
         };
     }
+
+    wait(): Promise<void> {
+        if (this.ready) {
+            return Promise.resolve();
+        }
+
+        return new Promise((resolve) => {
+            this.onReady(resolve);
+        });
+    }
 }


### PR DESCRIPTION
### Motivation

- Provide a way for consumers to await the router/world becoming ready so code can defer work until the runtime signals readiness.
- Consolidate ready state waiting logic into `ReadyState` so callers can receive a `Promise` instead of using callback subscription only.

### Description

- Added `waitForWorldLoad(): Promise<void>` to `KairoRouter` to expose a promise-based wait for the world/runtime readiness. 
- Implemented `ReadyState.wait(): Promise<void>` to return a promise that resolves when `ReadyState` becomes ready, using the existing `onReady` subscription internally.
- Introduced `worldLoadListener` disposable on the router and a private helper `startWorldLoadListener` that hooks the runtime `onReady` to mark the `ReadyState` ready and dispose the listener.
- Updated compiled outputs and type declarations (`lib/index.js`, `lib/index.d.ts`) to include the new API.

### Testing

- Ran a full TypeScript build using `npm run build` which completed successfully and emitted updated `lib` artifacts. 
- Ran the test suite with `npm test` and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbe247280c8333b7cb8817e2413c0b)