### PR TITLE
Fix activation event emissions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -13843,12 +13843,12 @@ var ActivationController = class {
   apply(request) {
     const next = request.type === "activate" ? "active" : "inactive";
     if (next === "inactive") {
-      this.eventRegistry.emitBefore("addonDeactivate", new AddonDeactivateBeforeEvent());
+      this.eventRegistry.emit("before", "addonDeactivate", new AddonDeactivateBeforeEvent());
     }
     this.contextMutator.setActivationState(next);
     if (next === "active") {
       this.lifecycle.onActivate();
-      this.eventRegistry.emitAfter("addonActivate", new AddonActivateAfterEvent());
+      this.eventRegistry.emit("after", "addonActivate", new AddonActivateAfterEvent());
     } else {
       this.lifecycle.onDeactivate();
       this.eventRegistry.clearActiveScopedListeners();

--- a/src/router/activation/ActivationController.ts
+++ b/src/router/activation/ActivationController.ts
@@ -36,7 +36,7 @@ export class ActivationController {
 
         // beforeEvents
         if (next === "inactive") {
-            this.eventRegistry.emitBefore("addonDeactivate", new AddonDeactivateBeforeEvent());
+            this.eventRegistry.emit("before", "addonDeactivate", new AddonDeactivateBeforeEvent());
         }
 
         this.contextMutator.setActivationState(next);
@@ -44,7 +44,7 @@ export class ActivationController {
         // afterEvents
         if (next === "active") {
             this.lifecycle.onActivate();
-            this.eventRegistry.emitAfter("addonActivate", new AddonActivateAfterEvent());
+            this.eventRegistry.emit("after", "addonActivate", new AddonActivateAfterEvent());
         } else {
             this.lifecycle.onDeactivate();
             this.eventRegistry.clearActiveScopedListeners();


### PR DESCRIPTION
### Motivation
- `ActivationController` が存在しない `emitBefore`/`emitAfter` を呼んでおりランタイムでエラーになっていたため、既存の `EventRegistry.emit` API を使ってエラーを解消しつつ想定の動作を維持する必要がありました。

### Description
- `src/router/activation/ActivationController.ts` の `this.eventRegistry.emitBefore("addonDeactivate", ...)` を `this.eventRegistry.emit("before", "addonDeactivate", ...)` に置き換えました。 
- 同ファイルの `this.eventRegistry.emitAfter("addonActivate", ...)` を `this.eventRegistry.emit("after", "addonActivate", ...)` に置き換えました。 
- ビルド出力の `lib/index.js` をソース変更に合わせて更新しました。 
- イベントのセマンティクス（`addonDeactivate` の before 発火と `addonActivate` の after 発火）と既存の `clearActiveScopedListeners` 呼び出しは変更していません。 

### Testing
- 実行したビルドで `pnpm build` を実行し成功しました。 
- 型チェックとして `pnpm exec tsc --noEmit` を実行し成功しました。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbef15fafc8333a15a8c1785818882)