### PR TITLE
Lazy-initialize JSON schema compilers and defer router ready marking

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1301,10 +1301,10 @@ var require_code = __commonJS({
     function interpolate(x) {
       return typeof x == "number" || typeof x == "boolean" || x === null ? x : safeStringify(Array.isArray(x) ? x.join(",") : x);
     }
-    function stringify(x) {
+    function stringify4(x) {
       return new _Code(safeStringify(x));
     }
-    exports.stringify = stringify;
+    exports.stringify = stringify4;
     function safeStringify(x) {
       return JSON.stringify(x).replace(/\u2028/g, "\\u2028").replace(/\u2029/g, "\\u2029");
     }
@@ -8140,9 +8140,9 @@ var require_validator = __commonJS({
     var ajvFormats = require_dist2();
     var clone = require_rfdc()({ proto: true });
     var Validator = class _Validator {
-      constructor(ajvOptions) {
+      constructor(ajvOptions2) {
         this.ajv = new Ajv2({
-          ...ajvOptions,
+          ...ajvOptions2,
           strictSchema: false,
           validateSchema: false,
           allowUnionTypes: true,
@@ -8158,7 +8158,7 @@ var require_validator = __commonJS({
           }
         });
         this._ajvSchemas = {};
-        this._ajvOptions = ajvOptions || {};
+        this._ajvOptions = ajvOptions2 || {};
       }
       addSchema(schema, schemaName) {
         let schemaKey = schema.$id || schemaName;
@@ -13844,7 +13844,11 @@ var ActivationResponseSchema = Type.Object(
 );
 
 // src/router/activation/response/stringify.ts
-var stringifyActivationResponse = (0, import_fast_json_stringify.default)(ActivationResponseSchema);
+var stringify;
+var stringifyActivationResponse = (response) => {
+  stringify ??= (0, import_fast_json_stringify.default)(ActivationResponseSchema);
+  return stringify(response);
+};
 
 // src/router/activation/ActivationResponder.ts
 var ActivationResponder = class {
@@ -13893,14 +13897,27 @@ var DEFAULT_MESSAGES4 = {
 
 // src/utils/ajv-compile.ts
 var import_ajv = __toESM(require_ajv(), 1);
-var ajv = new import_ajv.default({
+var ajvOptions = {
   allErrors: true,
   strict: true,
   removeAdditional: false,
   coerceTypes: false
-});
+};
+var ajv;
+function getAjv() {
+  ajv ??= new import_ajv.default(ajvOptions);
+  return ajv;
+}
 function compile(schema) {
-  return ajv.compile(schema);
+  let validate;
+  const lazyValidate = ((data) => {
+    validate ??= getAjv().compile(schema);
+    const valid = validate(data);
+    lazyValidate.errors = validate.errors;
+    return valid;
+  });
+  lazyValidate.errors = null;
+  return lazyValidate;
 }
 
 // src/router/activation/request/schema.ts
@@ -14306,7 +14323,11 @@ var DiscoveryResponseSchema = Type.Object(
 );
 
 // src/router/init/discovery/response/stringify.ts
-var stringifyDiscoveryResponse = (0, import_fast_json_stringify2.default)(DiscoveryResponseSchema);
+var stringify2;
+var stringifyDiscoveryResponse = (response) => {
+  stringify2 ??= (0, import_fast_json_stringify2.default)(DiscoveryResponseSchema);
+  return stringify2(response);
+};
 
 // src/router/init/discovery/DiscoveryResponder.ts
 var DiscoveryResponder = class {
@@ -14593,9 +14614,11 @@ var RegistrationResponseSchema = Type.Object(
 );
 
 // src/router/init/registration/response/stringify.ts
-var stringifyRegistrationResponse = (0, import_fast_json_stringify3.default)(
-  RegistrationResponseSchema
-);
+var stringify3;
+var stringifyRegistrationResponse = (response) => {
+  stringify3 ??= (0, import_fast_json_stringify3.default)(RegistrationResponseSchema);
+  return stringify3(response);
+};
 
 // src/router/init/registration/RegistrationResponder.ts
 var RegistrationResponder = class {
@@ -14857,7 +14880,9 @@ var KairoRouter = class {
     this.worldLoadListener = runtime.onReady(() => {
       this.worldLoadListener?.dispose();
       this.worldLoadListener = void 0;
-      this.readyState.markReady();
+      runtime.scheduler.runTimeout(() => {
+        this.readyState.markReady();
+      }, 1);
     });
   }
   startRouterListener() {

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -120,7 +120,10 @@ export class KairoRouter {
         this.worldLoadListener = runtime.onReady(() => {
             this.worldLoadListener?.dispose();
             this.worldLoadListener = undefined;
-            this.readyState.markReady();
+
+            runtime.scheduler.runTimeout(() => {
+                this.readyState.markReady();
+            }, 1);
         });
     }
 

--- a/src/router/activation/request/validate.ts
+++ b/src/router/activation/request/validate.ts
@@ -1,4 +1,4 @@
 import { compile } from "../../../utils/ajv-compile";
-import { ActivationRequest, ActivationRequestSchema } from "./schema";
+import { type ActivationRequest, ActivationRequestSchema } from "./schema";
 
 export const validateActivationRequest = compile<ActivationRequest>(ActivationRequestSchema);

--- a/src/router/activation/response/stringify.ts
+++ b/src/router/activation/response/stringify.ts
@@ -1,5 +1,9 @@
 import fastJson from "fast-json-stringify";
-import { ActivationResponse, ActivationResponseSchema } from "./schema";
+import { type ActivationResponse, ActivationResponseSchema } from "./schema";
 
-export const stringifyActivationResponse: (response: ActivationResponse) => string =
-    fastJson(ActivationResponseSchema);
+let stringify: ((response: ActivationResponse) => string) | undefined;
+
+export const stringifyActivationResponse = (response: ActivationResponse): string => {
+    stringify ??= fastJson(ActivationResponseSchema);
+    return stringify(response);
+};

--- a/src/router/init/discovery/response/stringify.ts
+++ b/src/router/init/discovery/response/stringify.ts
@@ -1,5 +1,9 @@
 import fastJson from "fast-json-stringify";
 import { type DiscoveryResponse, DiscoveryResponseSchema } from "./schema";
 
-export const stringifyDiscoveryResponse: (response: DiscoveryResponse) => string =
-    fastJson(DiscoveryResponseSchema);
+let stringify: ((response: DiscoveryResponse) => string) | undefined;
+
+export const stringifyDiscoveryResponse = (response: DiscoveryResponse): string => {
+    stringify ??= fastJson(DiscoveryResponseSchema);
+    return stringify(response);
+};

--- a/src/router/init/registration/response/stringify.ts
+++ b/src/router/init/registration/response/stringify.ts
@@ -1,6 +1,9 @@
 import fastJson from "fast-json-stringify";
 import { type RegistrationResponse, RegistrationResponseSchema } from "./schema";
 
-export const stringifyRegistrationResponse: (response: RegistrationResponse) => string = fastJson(
-    RegistrationResponseSchema,
-);
+let stringify: ((response: RegistrationResponse) => string) | undefined;
+
+export const stringifyRegistrationResponse = (response: RegistrationResponse): string => {
+    stringify ??= fastJson(RegistrationResponseSchema);
+    return stringify(response);
+};

--- a/src/utils/ajv-compile.ts
+++ b/src/utils/ajv-compile.ts
@@ -1,12 +1,30 @@
-import Ajv, { ValidateFunction } from "ajv";
+import Ajv, { type ValidateFunction } from "ajv";
 
-const ajv = new Ajv({
+const ajvOptions = {
     allErrors: true,
     strict: true,
     removeAdditional: false,
     coerceTypes: false,
-});
+};
+
+let ajv: Ajv | undefined;
+
+function getAjv(): Ajv {
+    ajv ??= new Ajv(ajvOptions);
+    return ajv;
+}
 
 export function compile<T>(schema: object): ValidateFunction<T> {
-    return ajv.compile<T>(schema);
+    let validate: ValidateFunction<T> | undefined;
+
+    const lazyValidate = ((data: unknown) => {
+        validate ??= getAjv().compile<T>(schema);
+        const valid = validate(data);
+        lazyValidate.errors = validate.errors;
+        return valid;
+    }) as ValidateFunction<T>;
+
+    lazyValidate.errors = null;
+
+    return lazyValidate;
 }


### PR DESCRIPTION
### Motivation
- Reduce startup cost and avoid eagerly compiling JSON schemas by initializing `fast-json-stringify` and `ajv` lazily when first used.
- Prevent a race or ordering issue during world-load by deferring the router `ready` transition to the runtime scheduler.
- Clarify typings and avoid accidental value imports by using `type` imports for schema types.

### Description
- Replace eager `fast-json-stringify(schema)` exports with a lazily-initialized cached `stringify` function for `ActivationResponse`, `DiscoveryResponse`, and `RegistrationResponse` so the actual compiler is created on first invocation.
- Refactor `utils/ajv-compile.ts` to lazily create the `Ajv` instance (`getAjv`) and return a `lazyValidate` wrapper that compiles the schema on first validation and forwards `errors` to the wrapper.
- Defer calling `readyState.markReady()` inside `startWorldLoadListener` by scheduling it via `runtime.scheduler.runTimeout(..., 1)` to avoid immediate timing issues.
- Use `import { type ... }` for schema types and adjust a few variable names (e.g. constructor param rename) to avoid shadowing and clarify intent.

### Testing
- Ran `npm run build` to produce the compiled `lib` artifacts and ensure TypeScript compilation succeeded, and it completed successfully.
- Executed `npm test` (project unit tests) and verification suites, which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e1d011208333a7665576bd6cd104)