### PR TITLE
Handle registration results and improve initializer/router lifecycle and error messages

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -357,14 +357,29 @@ var ActivationRequestParseError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES4[reason], { cause: options.cause });
+    super(REQUEST_PARSE_DEFAULT_MESSAGES[reason], { cause: options.cause });
     this.name = "ActivationRequestParseError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES4 = {
+var REQUEST_PARSE_DEFAULT_MESSAGES = {
   ["InvalidJSON" /* InvalidJSON */]: "Failed to parse ActivationRequest JSON.",
   ["InvalidStructure" /* InvalidStructure */]: "Invalid ActivationRequest structure."
+};
+var ActivationRequestError = class extends Error {
+  reason;
+  cause;
+  constructor(reason, options = {}) {
+    super(REQUEST_DEFAULT_MESSAGES[reason], { cause: options.cause });
+    this.name = "ActivationRequestError";
+    this.reason = reason;
+  }
+};
+var REQUEST_DEFAULT_MESSAGES = {
+  ["Timeout" /* Timeout */]: "ActivationRequest has timed out.",
+  ["FutureTimestamp" /* FutureTimestamp */]: "ActivationRequest timestamp is in the future.",
+  ["AlreadyActivated" /* AlreadyActivated */]: "Addon is already activated.",
+  ["AlreadyDeactivated" /* AlreadyDeactivated */]: "Addon is already deactivated."
 };
 
 // src/router/activation/request/validate.ts
@@ -402,25 +417,6 @@ var ActivationRequestParser = class {
 
 // src/router/activation/ActivationRequestValidator.ts
 import { validateTimestamp } from "@kairo-js/utils";
-
-// src/router/activation/errors.ts
-var ActivationRequestError = class extends Error {
-  reason;
-  cause;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES5[reason], { cause: options.cause });
-    this.name = "ActivationRequestError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES5 = {
-  ["Timeout" /* Timeout */]: "ActivationRequest has timed out.",
-  ["FutureTimestamp" /* FutureTimestamp */]: "ActivationRequest timestamp is in the future.",
-  ["AlreadyActivated" /* AlreadyActivated */]: "Addon is already activated.",
-  ["AlreadyDeactivated" /* AlreadyDeactivated */]: "Addon is already deactivated."
-};
-
-// src/router/activation/ActivationRequestValidator.ts
 var ActivationRequestValidator = class {
   TIMEOUT_TICKS = 10;
   validateRequest(request, currentTick, isActive) {
@@ -529,15 +525,15 @@ var KairoRouterInitError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES6[reason], { cause: options.cause });
+    super(DEFAULT_MESSAGES4[reason], { cause: options.cause });
     this.name = "KairoRouterInitError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES6 = {
+var DEFAULT_MESSAGES4 = {
   ["NotInitialized" /* NotInitialized */]: "Kairo router is not initialized. Call init() first.",
   ["AlreadyInitialized" /* AlreadyInitialized */]: "Kairo router has already been initialized.",
-  ["AlreadyDisposed" /* AlreadyDisposed */]: "Initializer is already disposed.",
+  ["AlreadyDisposed" /* AlreadyDisposed */]: "Kairo router is already disposed.",
   ["InvalidPhase" /* InvalidPhase */]: "Invalid phase for the requested operation.",
   ["RegistrationRejected" /* RegistrationRejected */]: "Addon registration was rejected.",
   ["RegistrationRequestNotFound" /* RegistrationRequestNotFound */]: "Registration request not found."
@@ -597,12 +593,12 @@ var ProvideKairoIdError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES7[reason], { cause: options.cause });
+    super(DEFAULT_MESSAGES5[reason], { cause: options.cause });
     this.name = "ProvideKairoIdError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES7 = {
+var DEFAULT_MESSAGES5 = {
   ["IdGenerationFailed" /* IdGenerationFailed */]: "Failed to generate a unique addon ID."
 };
 
@@ -654,14 +650,27 @@ var DiscoveryQueryParseError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES8[reason], { cause: options.cause });
+    super(QUERY_PARSE_DEFAULT_MESSAGES[reason], { cause: options.cause });
     this.name = "DiscoveryQueryParseError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES8 = {
+var QUERY_PARSE_DEFAULT_MESSAGES = {
   ["InvalidJSON" /* InvalidJSON */]: "Failed to parse DiscoveryQuery JSON.",
   ["InvalidStructure" /* InvalidStructure */]: "Invalid DiscoveryQuery structure."
+};
+var DiscoveryQueryError = class extends Error {
+  reason;
+  cause;
+  constructor(reason, options = {}) {
+    super(QUERY_DEFAULT_MESSAGES[reason], { cause: options.cause });
+    this.name = "DiscoveryQueryError";
+    this.reason = reason;
+  }
+};
+var QUERY_DEFAULT_MESSAGES = {
+  ["Timeout" /* Timeout */]: "DiscoveryQuery has timed out.",
+  ["FutureTimestamp" /* FutureTimestamp */]: "DiscoveryQuery timestamp is in the future."
 };
 
 // src/router/init/discovery/query/validate.ts
@@ -703,23 +712,6 @@ var DiscoveryQueryParser = class {
 
 // src/router/init/discovery/DiscoveryQueryValidator.ts
 import { validateTimestamp as validateTimestamp2 } from "@kairo-js/utils";
-
-// src/router/init/discovery/errors.ts
-var DiscoveryQueryError = class extends Error {
-  reason;
-  cause;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES9[reason], { cause: options.cause });
-    this.name = "DiscoveryQueryError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES9 = {
-  ["Timeout" /* Timeout */]: "DiscoveryQuery has timed out.",
-  ["FutureTimestamp" /* FutureTimestamp */]: "DiscoveryQuery timestamp is in the future."
-};
-
-// src/router/init/discovery/DiscoveryQueryValidator.ts
 var DiscoveryQueryValidator = class {
   TIMEOUT_TICKS = 10;
   validateRequest(query, currentTick) {
@@ -759,12 +751,12 @@ var DiscoveryResponseError = class extends Error {
   reason;
   cause;
   constructor(reason, options) {
-    super(DEFAULT_MESSAGES10[reason], { cause: options.cause });
+    super(DEFAULT_MESSAGES6[reason], { cause: options.cause });
     this.name = "DiscoveryResponseError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES10 = {
+var DEFAULT_MESSAGES6 = {
   ["StringifyFailed" /* StringifyFailed */]: "Failed to stringify discovery response."
 };
 
@@ -829,12 +821,12 @@ var KairoListenerError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES11[reason], { cause: options.cause });
+    super(DEFAULT_MESSAGES7[reason], { cause: options.cause });
     this.name = "KairoListenerError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES11 = {
+var DEFAULT_MESSAGES7 = {
   ["AlreadySetUp" /* AlreadySetUp */]: "Listener is already set up."
 };
 
@@ -928,14 +920,27 @@ var RegistrationRequestParseError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES12[reason], { cause: options.cause });
+    super(REQUEST_PARSE_DEFAULT_MESSAGES2[reason], { cause: options.cause });
     this.name = "RegistrationRequestParseError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES12 = {
+var REQUEST_PARSE_DEFAULT_MESSAGES2 = {
   ["InvalidJSON" /* InvalidJSON */]: "Failed to parse RegistrationRequest JSON.",
   ["InvalidStructure" /* InvalidStructure */]: "Invalid RegistrationRequest structure."
+};
+var RegistrationRequestError = class extends Error {
+  reason;
+  cause;
+  constructor(reason, options = {}) {
+    super(REQUEST_DEFAULT_MESSAGES2[reason], { cause: options.cause });
+    this.name = "RegistrationRequestError";
+    this.reason = reason;
+  }
+};
+var REQUEST_DEFAULT_MESSAGES2 = {
+  ["Timeout" /* Timeout */]: "RegistrationRequest has timed out.",
+  ["FutureTimestamp" /* FutureTimestamp */]: "RegistrationRequest timestamp is in the future."
 };
 
 // src/router/init/registration/request/validate.ts
@@ -977,23 +982,6 @@ var RegistrationRequestParser = class {
 
 // src/router/init/registration/RegistrationRequestValidator.ts
 import { validateTimestamp as validateTimestamp3 } from "@kairo-js/utils";
-
-// src/router/init/registration/errors.ts
-var RegistrationRequestError = class extends Error {
-  reason;
-  cause;
-  constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES13[reason], { cause: options.cause });
-    this.name = "RegistrationRequestError";
-    this.reason = reason;
-  }
-};
-var DEFAULT_MESSAGES13 = {
-  ["Timeout" /* Timeout */]: "RegistrationRequest has timed out.",
-  ["FutureTimestamp" /* FutureTimestamp */]: "RegistrationRequest timestamp is in the future."
-};
-
-// src/router/init/registration/RegistrationRequestValidator.ts
 var RegistrationRequestValidator = class {
   TIMEOUT_TICKS = 10;
   validateRequest(request, currentTick) {
@@ -1010,16 +998,105 @@ var RegistrationRequestValidator = class {
   }
 };
 
+// src/router/init/registration/RegistrationResultParser.ts
+import { safeJsonParse as safeJsonParse4, toError as toError6 } from "@kairo-js/utils";
+
+// src/router/init/registration/result/errors.ts
+var RegistrationResultParseError = class extends Error {
+  reason;
+  cause;
+  constructor(reason, options = {}) {
+    super(RESULT_PARSE_DEFAULT_MESSAGES[reason], { cause: options.cause });
+    this.name = "RegistrationResultParseError";
+    this.reason = reason;
+  }
+};
+var RESULT_PARSE_DEFAULT_MESSAGES = {
+  ["InvalidJSON" /* InvalidJSON */]: "Failed to parse RegistrationResult JSON.",
+  ["InvalidStructure" /* InvalidStructure */]: "Invalid RegistrationResult structure."
+};
+var RegistrationResultError = class extends Error {
+  reason;
+  cause;
+  constructor(reason, options = {}) {
+    super(RESULT_DEFAULT_MESSAGES[reason], { cause: options.cause });
+    this.name = "RegistrationResultError";
+    this.reason = reason;
+  }
+};
+var RESULT_DEFAULT_MESSAGES = {
+  ["Timeout" /* Timeout */]: "RegistrationResult has timed out.",
+  ["FutureTimestamp" /* FutureTimestamp */]: "RegistrationResult timestamp is in the future."
+};
+
+// src/router/init/registration/result/validate.ts
+import { compile as compile4 } from "@kairo-js/utils";
+
+// src/router/init/registration/result/schema.ts
+import { Type as Type6 } from "@sinclair/typebox";
+var RegistrationResultSchema = Type6.Object(
+  {
+    kairoId: Type6.String(),
+    success: Type6.Boolean(),
+    reason: Type6.Optional(Type6.String()),
+    timestamp: Type6.Integer({ minimum: 0 })
+  },
+  {
+    additionalProperties: false
+  }
+);
+
+// src/router/init/registration/result/validate.ts
+var validateRegistrationResult = compile4(RegistrationResultSchema);
+
+// src/router/init/registration/RegistrationResultParser.ts
+var RegistrationResultParser = class {
+  parse(message) {
+    const parsed = safeJsonParse4(
+      message,
+      () => new RegistrationResultParseError("InvalidJSON" /* InvalidJSON */)
+    );
+    if (!validateRegistrationResult(parsed)) {
+      throw new RegistrationResultParseError(
+        "InvalidStructure" /* InvalidStructure */,
+        { cause: toError6(validateRegistrationResult.errors) }
+      );
+    }
+    const result = parsed;
+    return result;
+  }
+};
+
+// src/router/init/registration/RegistrationResultValidator.ts
+import { validateTimestamp as validateTimestamp4 } from "@kairo-js/utils";
+var RegistrationResultValidator = class {
+  TIMEOUT_TICKS = 10;
+  validateRequest(result, currentTick) {
+    this.validateTimestamp(result, currentTick);
+  }
+  validateTimestamp(result, currentTick) {
+    validateTimestamp4(
+      currentTick,
+      result.timestamp,
+      this.TIMEOUT_TICKS,
+      () => new RegistrationResultError("Timeout" /* Timeout */),
+      () => new RegistrationResultError("FutureTimestamp" /* FutureTimestamp */)
+    );
+  }
+};
+
 // src/router/init/registration/AddonRegistrationManager.ts
 var AddonRegistrationManager = class {
   constructor(registryBuilder) {
     this.registryBuilder = registryBuilder;
   }
-  parser = new RegistrationRequestParser();
-  validator = new RegistrationRequestValidator();
+  requestParser = new RegistrationRequestParser();
+  requestValidator = new RegistrationRequestValidator();
+  resultParser = new RegistrationResultParser();
+  resultValidator = new RegistrationResultValidator();
   resolveRegistry(message, currentTick, kairoId, addonProperties) {
-    const request = this.parser.parse(message);
-    this.validator.validateRequest(request, currentTick);
+    const request = this.requestParser.parse(message);
+    this.requestValidator.validateRequest(request, currentTick);
     if (request.rejects.includes(kairoId)) {
       throw new KairoRouterInitError("RegistrationRejected" /* RegistrationRejected */);
     }
@@ -1029,22 +1106,27 @@ var AddonRegistrationManager = class {
     const registry = this.registryBuilder.build(kairoId, addonProperties);
     return registry;
   }
+  resolveResult(message, currentTick) {
+    const result = this.resultParser.parse(message);
+    this.resultValidator.validateRequest(result, currentTick);
+    return result.success;
+  }
 };
 
 // src/router/init/registration/RegistrationResponder.ts
-import { toError as toError6 } from "@kairo-js/utils";
+import { toError as toError7 } from "@kairo-js/utils";
 
 // src/router/init/registration/response/errors.ts
 var RegistrationResponseError = class extends Error {
   reason;
   cause;
   constructor(reason, options = {}) {
-    super(DEFAULT_MESSAGES14[reason], { cause: options.cause });
+    super(DEFAULT_MESSAGES8[reason], { cause: options.cause });
     this.name = "RegistrationResponseError";
     this.reason = reason;
   }
 };
-var DEFAULT_MESSAGES14 = {
+var DEFAULT_MESSAGES8 = {
   ["StringifyFailed" /* StringifyFailed */]: "Failed to stringify registration response."
 };
 
@@ -1052,30 +1134,30 @@ var DEFAULT_MESSAGES14 = {
 import fastJson3 from "fast-json-stringify";
 
 // src/router/init/registration/response/schema.ts
-import { Type as Type6 } from "@sinclair/typebox";
-var RegistrationResponseSchema = Type6.Object(
+import { Type as Type7 } from "@sinclair/typebox";
+var RegistrationResponseSchema = Type7.Object(
   {
-    kairoRegistry: Type6.Object({
-      kairoId: Type6.String(),
-      addonId: Type6.String(),
-      name: Type6.String(),
-      description: Type6.String(),
-      version: Type6.Object({
-        major: Type6.Number(),
-        minor: Type6.Number(),
-        patch: Type6.Number(),
-        prerelease: Type6.Optional(Type6.String()),
-        build: Type6.Optional(Type6.String())
+    kairoRegistry: Type7.Object({
+      kairoId: Type7.String(),
+      addonId: Type7.String(),
+      name: Type7.String(),
+      description: Type7.String(),
+      version: Type7.Object({
+        major: Type7.Number(),
+        minor: Type7.Number(),
+        patch: Type7.Number(),
+        prerelease: Type7.Optional(Type7.String()),
+        build: Type7.Optional(Type7.String())
       }),
-      metadata: Type6.Object({
-        authors: Type6.Array(Type6.String()),
-        url: Type6.Optional(Type6.String()),
-        license: Type6.Optional(Type6.String())
+      metadata: Type7.Object({
+        authors: Type7.Array(Type7.String()),
+        url: Type7.Optional(Type7.String()),
+        license: Type7.Optional(Type7.String())
       }),
-      requiredAddons: Type6.Record(Type6.String(), Type6.String()),
-      tags: Type6.Array(Type6.String())
+      requiredAddons: Type7.Record(Type7.String(), Type7.String()),
+      tags: Type7.Array(Type7.String())
     }),
-    timestamp: Type6.Integer({ minimum: 0 })
+    timestamp: Type7.Integer({ minimum: 0 })
   },
   {
     additionalProperties: false
@@ -1101,7 +1183,7 @@ var RegistrationResponder = class {
       runtime.send("kairo:registration_response" /* RegistrationResponse */, responseStr);
     } catch (e) {
       throw new RegistrationResponseError("StringifyFailed" /* StringifyFailed */, {
-        cause: toError6(e)
+        cause: toError7(e)
       });
     }
   }
@@ -1128,6 +1210,9 @@ var RegistrationController = class {
     deps.contextMutator.setKairoRegistry(registry);
     return registry;
   };
+  handleRegistrationResult = (message, deps) => {
+    return this.registrationManager.resolveResult(message, deps.runtime.currentTick());
+  };
 };
 
 // src/router/init/KairoInitializer.ts
@@ -1146,7 +1231,8 @@ var KairoInitializer = class {
     this.registrationController = new RegistrationController(this.registryBuilder);
     this.initListener = new KairoInitListener(this.readyState, {
       ["kairo:discovery_query" /* DiscoveryQuery */]: this.handleDiscoveryQuery,
-      ["kairo:registration_request" /* RegistrationRequest */]: this.handleRegistrationRequest
+      ["kairo:registration_request" /* RegistrationRequest */]: this.handleRegistrationRequest,
+      ["kairo:registration_result" /* RegistrationResult */]: this.handleRegistrationResult
     });
   }
   subscription;
@@ -1162,13 +1248,22 @@ var KairoInitializer = class {
   }
   dispose() {
     if (this.phase === 3 /* Disposed */) return;
+    if (this.phase === 2 /* Completed */) {
+      this.disposeSubscription();
+      return;
+    }
     this.phase = 3 /* Disposed */;
+    this.disposeSubscription();
+    this.onDisposed?.();
+  }
+  complete() {
+    this.phase = 2 /* Completed */;
+    this.disposeSubscription();
+    this.onCompleted?.();
+  }
+  disposeSubscription() {
     this.subscription?.dispose();
     this.subscription = void 0;
-    try {
-      this.onDisposed?.();
-    } catch {
-    }
   }
   handleDiscoveryQuery = (message) => {
     this.assertPhase(0 /* Discovery */);
@@ -1196,9 +1291,22 @@ var KairoInitializer = class {
         this.dispose();
         return;
       }
-      this.phase = 2 /* Completed */;
+    } catch (error) {
       this.dispose();
-      this.onCompleted?.();
+      throw error;
+    }
+  };
+  handleRegistrationResult = (message) => {
+    this.assertPhase(1 /* Registration */);
+    try {
+      const isSuccess = this.registrationController.handleRegistrationResult(message, {
+        runtime: this.runtime
+      });
+      if (!isSuccess) {
+        this.dispose();
+        return;
+      }
+      this.complete();
     } catch (error) {
       this.dispose();
       throw error;
@@ -1281,6 +1389,8 @@ var KairoRouter = class {
   routerListener;
   runtimeInjectedEventListener;
   worldLoadListener;
+  initializer;
+  disposed = false;
   eventRegistry = new EventRegistry(() => {
     if (!this.kairoContext) return false;
     return this.kairoContext.isActive();
@@ -1288,6 +1398,7 @@ var KairoRouter = class {
   afterEvents = new KairoAfterEvents(this.eventRegistry);
   beforeEvents = new KairoBeforeEvents(this.eventRegistry);
   get currentTick() {
+    this.assertNotDisposed();
     if (!this.runtime) {
       throw new KairoRouterInitError("NotInitialized" /* NotInitialized */);
     }
@@ -1305,6 +1416,7 @@ var KairoRouter = class {
     this.scheduler.clearRun(runId);
   }
   init(properties) {
+    this.assertNotDisposed();
     if (this.kairoContext) {
       throw new KairoRouterInitError("AlreadyInitialized" /* AlreadyInitialized */);
     }
@@ -1320,11 +1432,20 @@ var KairoRouter = class {
       mutator,
       new SeedRandom2(),
       this.readyState,
-      () => this.startRouterListener()
+      () => {
+        this.initializer = void 0;
+        this.startRouterListener();
+      },
+      () => {
+        this.initializer = void 0;
+        this.dispose();
+      }
     );
+    this.initializer = initializer;
     initializer.setup();
   }
   waitForWorldLoad() {
+    this.assertNotDisposed();
     this.startWorldLoadListener(this.runtime ?? new KairoRuntime());
     return this.readyState.wait();
   }
@@ -1341,6 +1462,25 @@ var KairoRouter = class {
     return this.scheduler.runTimeout(callback, tickDelay);
   }
   send(targetId, eventId, ...args) {
+  }
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.initializer?.dispose();
+    this.initializer = void 0;
+    this.stopActivationTickCounter();
+    this.detachRuntimeEvents();
+    this.routerListener?.dispose();
+    this.routerListener = void 0;
+    this.worldLoadListener?.dispose();
+    this.worldLoadListener = void 0;
+    this.eventRegistry.clearActiveScopedListeners();
+    this.kairoContextMutator?.setActivationState("inactive");
+    this.scheduler?.setActive(false);
+    this.kairoContext = void 0;
+    this.kairoContextMutator = void 0;
+    this.scheduler = void 0;
+    this.runtime = void 0;
   }
   startWorldLoadListener(runtime) {
     if (this.readyState.isReady() || this.worldLoadListener) return;
@@ -1432,11 +1572,17 @@ var KairoRouter = class {
     this.activationCurrentTick = 0;
   }
   assertRunnable() {
+    this.assertNotDisposed();
     if (!this.kairoContext || !this.runtime || !this.scheduler) {
       throw new KairoRouterInitError("NotInitialized" /* NotInitialized */);
     }
     if (!this.kairoContext.isActive()) {
       throw new KairoRouterError("Inactive" /* Inactive */);
+    }
+  }
+  assertNotDisposed() {
+    if (this.disposed) {
+      throw new KairoRouterInitError("AlreadyDisposed" /* AlreadyDisposed */);
     }
   }
 };

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -29,6 +29,8 @@ export class KairoRouter {
     private routerListener?: Disposable;
     private runtimeInjectedEventListener?: Disposable;
     private worldLoadListener?: Disposable;
+    private initializer?: Disposable;
+    private disposed = false;
 
     private eventRegistry = new EventRegistry(() => {
         if (!this.kairoContext) return false;
@@ -38,6 +40,8 @@ export class KairoRouter {
     public readonly beforeEvents = new KairoBeforeEvents<KairoEventMap>(this.eventRegistry);
 
     get currentTick(): number {
+        this.assertNotDisposed();
+
         if (!this.runtime) {
             throw new KairoRouterInitError(KairoRouterInitErrorReason.NotInitialized);
         }
@@ -58,6 +62,8 @@ export class KairoRouter {
     }
 
     init(properties: AddonProperties): void {
+        this.assertNotDisposed();
+
         if (this.kairoContext) {
             throw new KairoRouterInitError(KairoRouterInitErrorReason.AlreadyInitialized);
         }
@@ -77,13 +83,22 @@ export class KairoRouter {
             mutator,
             new SeedRandom(),
             this.readyState,
-            () => this.startRouterListener(),
+            () => {
+                this.initializer = undefined;
+                this.startRouterListener();
+            },
+            () => {
+                this.initializer = undefined;
+                this.dispose();
+            },
         );
 
+        this.initializer = initializer;
         initializer.setup();
     }
 
     waitForWorldLoad(): Promise<void> {
+        this.assertNotDisposed();
         this.startWorldLoadListener(this.runtime ?? new KairoRuntime());
         return this.readyState.wait();
     }
@@ -112,6 +127,33 @@ export class KairoRouter {
     }
 
     send(targetId: string, eventId: string, ...args: unknown[]): void {}
+
+    private dispose(): void {
+        if (this.disposed) return;
+
+        this.disposed = true;
+
+        this.initializer?.dispose();
+        this.initializer = undefined;
+
+        this.stopActivationTickCounter();
+        this.detachRuntimeEvents();
+
+        this.routerListener?.dispose();
+        this.routerListener = undefined;
+
+        this.worldLoadListener?.dispose();
+        this.worldLoadListener = undefined;
+
+        this.eventRegistry.clearActiveScopedListeners();
+        this.kairoContextMutator?.setActivationState("inactive");
+        this.scheduler?.setActive(false);
+
+        this.kairoContext = undefined;
+        this.kairoContextMutator = undefined;
+        this.scheduler = undefined;
+        this.runtime = undefined;
+    }
 
     private startWorldLoadListener(runtime: KairoRuntime<KairoEventMap>): void {
         if (this.readyState.isReady() || this.worldLoadListener) return;
@@ -222,12 +264,20 @@ export class KairoRouter {
     }
 
     private assertRunnable(): void {
+        this.assertNotDisposed();
+
         if (!this.kairoContext || !this.runtime || !this.scheduler) {
             throw new KairoRouterInitError(KairoRouterInitErrorReason.NotInitialized);
         }
 
         if (!this.kairoContext.isActive()) {
             throw new KairoRouterError(KairoRouterErrorReason.Inactive);
+        }
+    }
+
+    private assertNotDisposed(): void {
+        if (this.disposed) {
+            throw new KairoRouterInitError(KairoRouterInitErrorReason.AlreadyDisposed);
         }
     }
 }

--- a/src/router/init/KairoInitializer.ts
+++ b/src/router/init/KairoInitializer.ts
@@ -60,15 +60,27 @@ export class KairoInitializer implements Disposable {
 
     dispose(): void {
         if (this.phase === InitPhase.Disposed) return;
+        if (this.phase === InitPhase.Completed) {
+            this.disposeSubscription();
+            return;
+        }
 
         this.phase = InitPhase.Disposed;
+        this.disposeSubscription();
 
+        this.onDisposed?.();
+    }
+
+    private complete(): void {
+        this.phase = InitPhase.Completed;
+        this.disposeSubscription();
+
+        this.onCompleted?.();
+    }
+
+    private disposeSubscription(): void {
         this.subscription?.dispose();
         this.subscription = undefined;
-
-        try {
-            this.onDisposed?.();
-        } catch {}
     }
 
     private handleDiscoveryQuery = (message: string): void => {
@@ -116,9 +128,12 @@ export class KairoInitializer implements Disposable {
                 runtime: this.runtime,
             });
 
-            this.phase = InitPhase.Completed;
-            this.dispose();
-            this.onCompleted?.();
+            if (!isSuccess) {
+                this.dispose();
+                return;
+            }
+
+            this.complete();
         } catch (error) {
             this.dispose();
             throw error;

--- a/src/router/init/errors.ts
+++ b/src/router/init/errors.ts
@@ -23,7 +23,7 @@ const DEFAULT_MESSAGES: Record<KairoRouterInitErrorReason, string> = {
     [KairoRouterInitErrorReason.NotInitialized]:
         "Kairo router is not initialized. Call init() first.",
     [KairoRouterInitErrorReason.AlreadyInitialized]: "Kairo router has already been initialized.",
-    [KairoRouterInitErrorReason.AlreadyDisposed]: "Initializer is already disposed.",
+    [KairoRouterInitErrorReason.AlreadyDisposed]: "Kairo router is already disposed.",
     [KairoRouterInitErrorReason.InvalidPhase]: "Invalid phase for the requested operation.",
     [KairoRouterInitErrorReason.RegistrationRejected]: "Addon registration was rejected.",
     [KairoRouterInitErrorReason.RegistrationRequestNotFound]: "Registration request not found.",


### PR DESCRIPTION
### Motivation
- Add support for processing `RegistrationResult` messages during initialization and make initializer lifecycle explicit so initialization can complete or be disposed cleanly.
- Improve disposal and resource cleanup for the router and initializer to avoid leaking subscriptions and to allow re-use/guarded operations.
- Standardize and fix names for error message constants and introduce clearer parse/result error classes for discovery/activation/registration flows.

### Description
- Add full `RegistrationResult` handling: new `RegistrationResultParser`, `RegistrationResultValidator`, schema, and corresponding manager logic to parse/validate results and return success state.
- Extend `KairoInitializer` to handle `registration_result` events, add `complete()`, `disposeSubscription()` and refined `dispose()` behavior so completed and disposed states are handled correctly.
- Track and dispose the initializer from `KairoRouter`; add `disposed` flag, `dispose()` method, and `assertNotDisposed()` checks to prevent operations after disposal and to ensure proper cleanup of scheduler, listeners, and runtime resources.
- Rename and consolidate many error message constants and error classes (parse/error/default message constants) across activation, discovery and registration flows to avoid duplicated identifiers and to provide clearer error constructors.
- Minor refactors: adjust stringify/parse imports and TypeBox type references, wire new registration-result flow into registration controller and initializer callbacks, and ensure startup callback clears the stored initializer reference.

### Testing
- Project build and type-check (`tsc`) were executed and completed successfully.
- Existing automated unit tests were run against the modified codebase and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032c6a9c748333ac92203fb45b93dd)