### PR TITLE
Fix activation request listener routing

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -290,13 +290,6 @@ function createKairoContext(properties) {
 // src/router/activation/ActivationResponder.ts
 import { toError } from "@kairo-js/utils";
 
-// src/router/KairoEventId.ts
-var KairoEventId = /* @__PURE__ */ ((KairoEventId2) => {
-  KairoEventId2["ActivationRequest"] = "activation_request";
-  KairoEventId2["ActivationResponse"] = "kairo:activetion_response";
-  return KairoEventId2;
-})(KairoEventId || {});
-
 // src/router/activation/response/errors.ts
 var ActivationResponseError = class extends Error {
   reason;
@@ -1338,14 +1331,13 @@ var KairoInitializer = class {
 };
 
 // src/router/KairoRouterListener.ts
-var KAIRO_EVENT_ID_SET = new Set(Object.values(KairoEventId));
 var KairoRouterListener = class extends ReadyBufferedListener {
   constructor(readyState, handlers) {
     super(readyState);
     this.handlers = handlers;
   }
   filter(id) {
-    return KAIRO_EVENT_ID_SET.has(id);
+    return Object.hasOwn(this.handlers, id);
   }
   handle(id, message) {
     this.handlers?.[id]?.(message);

--- a/src/router/KairoRouterListener.ts
+++ b/src/router/KairoRouterListener.ts
@@ -1,23 +1,22 @@
-import { KairoEventId } from "./KairoEventId";
 import { ReadyBufferedListener } from "./ReadyBufferedListener";
 import { ReadyState } from "./ReadyState";
 
 type Handler = (message: string) => void;
-const KAIRO_EVENT_ID_SET = new Set<KairoEventId>(Object.values(KairoEventId));
+type HandlerMap = Partial<Record<string, Handler>>;
 
-export class KairoRouterListener extends ReadyBufferedListener<KairoEventId> {
+export class KairoRouterListener extends ReadyBufferedListener<string> {
     constructor(
         readyState: ReadyState,
-        private readonly handlers: Partial<Record<KairoEventId, Handler>>,
+        private readonly handlers: HandlerMap,
     ) {
         super(readyState);
     }
 
-    protected filter(id: string): id is KairoEventId {
-        return KAIRO_EVENT_ID_SET.has(id as KairoEventId);
+    protected filter(id: string): id is string {
+        return Object.hasOwn(this.handlers, id);
     }
 
-    protected handle(id: KairoEventId, message: string): void {
+    protected handle(id: string, message: string): void {
         this.handlers?.[id]?.(message);
     }
 }


### PR DESCRIPTION
### Motivation
- The router registers dynamic event IDs like `<kairoId>:activation_request`, but `KairoRouterListener` only allowed IDs defined in the `KairoEventId` enum, causing dynamic activation requests to be dropped before reaching `handleActivationRequest`.

### Description
- Change `KairoRouterListener` to accept `string` IDs and use a handler map type `Partial<Record<string, Handler>>` instead of the `KairoEventId` enum.
- Replace the static enum-based filter with a runtime check `Object.hasOwn(this.handlers, id)` so registered dynamic keys (e.g. `<kairoId>:activation_request`) pass the filter.
- Adjust the listener generics and handler signatures to `ReadyBufferedListener<string>` and `protected handle(id: string, message: string)`.
- Rebuilt the generated output (`lib/index.js` and `.d.ts`) so the runtime bundle reflects the change.

### Testing
- Ran `pnpm build`, which completed successfully.
- Ran `pnpm exec tsc --noEmit` (typecheck), which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0542478fc48333bb0715aa9063e4a4)