### PR TITLE
feat: implement API communication protocol (API_SPEC)

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,5 +1,65 @@
 import { SemVer, AddonProperties } from '@kairo-js/properties';
 import { BlockExplodeAfterEvent, ButtonPushAfterEvent, DataDrivenEntityTriggerAfterEvent, EffectAddAfterEvent, EntityDieAfterEvent, EntityHealAfterEvent, EntityHealthChangedAfterEvent, EntityHitBlockAfterEvent, EntityHitEntityAfterEvent, EntityHurtAfterEvent, EntityItemDropAfterEvent, EntityItemPickupAfterEvent, EntityLoadAfterEvent, EntityRemoveAfterEvent, EntitySpawnAfterEvent, ExplosionAfterEvent, GameRuleChangeAfterEvent, ItemCompleteUseAfterEvent, ItemReleaseUseAfterEvent, ItemStartUseAfterEvent, ItemStartUseOnAfterEvent, ItemStopUseAfterEvent, ItemStopUseOnAfterEvent, ItemUseAfterEvent, LeverActionAfterEvent, PistonActivateAfterEvent, PlayerBreakBlockAfterEvent, PlayerButtonInputAfterEvent, PlayerDimensionChangeAfterEvent, PlayerEmoteAfterEvent, PlayerGameModeChangeAfterEvent, PlayerHotbarSelectedSlotChangeAfterEvent, PlayerInputModeChangeAfterEvent, PlayerInputPermissionCategoryChangeAfterEvent, PlayerInteractWithBlockAfterEvent, PlayerInteractWithEntityAfterEvent, PlayerInventoryItemChangeAfterEvent, PlayerJoinAfterEvent, PlayerLeaveAfterEvent, PlayerPlaceBlockAfterEvent, PlayerSpawnAfterEvent, PlayerSwingStartAfterEvent, PressurePlatePopAfterEvent, PressurePlatePushAfterEvent, ProjectileHitBlockAfterEvent, ProjectileHitEntityAfterEvent, ScriptEventCommandMessageAfterEvent, TargetBlockHitAfterEvent, TripWireTripAfterEvent, WeatherChangeAfterEvent, EffectAddBeforeEvent, EntityHealBeforeEvent, EntityItemPickupBeforeEvent, EntityRemoveBeforeEvent, ExplosionBeforeEvent, ItemUseBeforeEvent, PlayerBreakBlockBeforeEvent, PlayerGameModeChangeBeforeEvent, PlayerInteractWithBlockBeforeEvent, PlayerInteractWithEntityBeforeEvent, PlayerLeaveBeforeEvent, ShutdownEvent, WeatherChangeBeforeEvent, CustomCommandRegistry, CustomCommand, CustomCommandOrigin, CustomCommandResult, StartupEvent } from '@minecraft/server';
+import * as _sinclair_typebox from '@sinclair/typebox';
+import { Static } from '@sinclair/typebox';
+
+interface Disposable {
+    dispose(): void;
+}
+
+type DeepReadonly<T> = T extends readonly (infer U)[] ? ReadonlyArray<DeepReadonly<U>> : T extends object ? {
+    readonly [K in keyof T]: DeepReadonly<T[K]>;
+} : T;
+type BeforeHookContext<TArgs, TReturn> = {
+    args: TArgs;
+    readonly callerAddonId: string;
+    cancel(result?: TReturn): never;
+    setRollbackData(data: unknown): void;
+};
+type AfterHookContext<TArgs, TReturn> = {
+    readonly args: TArgs;
+    result: TReturn;
+    readonly callerAddonId: string;
+};
+type HookRollbackContext<TArgs> = {
+    readonly rollbackData: unknown;
+    readonly currentArgsSnapshot: DeepReadonly<TArgs>;
+    readonly callerAddonId: string;
+};
+type HookOptions<TArgs, TReturn> = {
+    priority?: number;
+    modes?: ReadonlyArray<"send" | "request">;
+    before?: (ctx: BeforeHookContext<TArgs, TReturn>) => Promise<void>;
+    after?: (ctx: AfterHookContext<TArgs, TReturn>) => Promise<void>;
+    rollback?: (ctx: HookRollbackContext<TArgs>) => Promise<TArgs | void>;
+};
+type ApiHandler = (args: any) => any;
+type InternalHookDeclaration = {
+    readonly targetAddonId: string;
+    readonly apiName: string;
+    readonly priority: number;
+    readonly modes: ReadonlyArray<"send" | "request">;
+    readonly sequence: number;
+    declaringAddonId?: string;
+    readonly before?: (ctx: BeforeHookContext<any, any>) => Promise<void>;
+    readonly after?: (ctx: AfterHookContext<any, any>) => Promise<void>;
+    readonly rollback?: (ctx: HookRollbackContext<any>) => Promise<any | void>;
+};
+declare class KairoApiRegistry implements Disposable {
+    private sealed;
+    private readonly apiHandlers;
+    private readonly hookDeclarations;
+    private sequenceCounter;
+    register<TArgs, TReturn>(apiName: string, handler: (args: TArgs) => TReturn | Promise<TReturn>): void;
+    hook<TArgs, TReturn>(targetAddonId: string, apiName: string, options: HookOptions<TArgs, TReturn>): void;
+    seal(): void;
+    setDeclaringAddonId(addonId: string): void;
+    getApiHandler(apiName: string): ApiHandler | undefined;
+    getApiNames(): ReadonlyArray<string>;
+    getHookDeclarations(): readonly InternalHookDeclaration[];
+    dispose(): void;
+    private assertNotSealed;
+}
 
 declare class AddonActivateAfterEvent {
     private constructor();
@@ -81,54 +141,32 @@ interface KairoEventMap {
     };
 }
 
-interface Disposable {
-    dispose(): void;
+declare class ApiNotFoundError extends Error {
+    constructor(apiName?: string);
 }
-
-type BeforeHookContext<TArgs, TReturn> = {
-    args: TArgs;
-    result: TReturn | undefined;
-    readonly callerAddonId: string;
-    cancel(): void;
-};
-type AfterHookContext<TArgs, TReturn> = {
-    readonly args: Readonly<TArgs>;
-    result: TReturn;
-    readonly callerAddonId: string;
-};
-type HookRollbackContext<TArgs> = {
-    readonly args: Readonly<TArgs>;
-    readonly callerAddonId: string;
-};
-type HookOptions<TArgs, TReturn> = {
-    priority?: number;
-    version?: string;
-    before?: (ctx: BeforeHookContext<TArgs, TReturn>) => Promise<void>;
-    after?: (ctx: AfterHookContext<TArgs, TReturn>) => Promise<void>;
-    rollback?: (ctx: HookRollbackContext<TArgs>) => Promise<void>;
-};
-type ApiHandler = (args: any) => any;
-type InternalHookDeclaration = {
-    readonly targetAddonId: string;
-    readonly apiName: string;
-    readonly priority: number;
-    readonly version?: string;
-    readonly before?: (ctx: BeforeHookContext<any, any>) => Promise<void>;
-    readonly after?: (ctx: AfterHookContext<any, any>) => Promise<void>;
-    readonly rollback?: (ctx: HookRollbackContext<any>) => Promise<void>;
-};
-declare class KairoApiRegistry implements Disposable {
-    private sealed;
-    private readonly apiHandlers;
-    private readonly hookDeclarations;
-    register<TArgs, TReturn>(apiName: string, handler: (args: TArgs) => TReturn | Promise<TReturn>): void;
-    hook<TArgs, TReturn>(targetAddonId: string, apiName: string, options: HookOptions<TArgs, TReturn>): void;
-    seal(): void;
-    getApiHandlers(): ReadonlyMap<string, ApiHandler>;
-    getHookDeclarations(): readonly InternalHookDeclaration[];
-    dispose(): void;
-    private assertNotSealed;
+declare class RequestTimeoutError extends Error {
+    constructor();
 }
+declare class BeforeHookExecutionError extends Error {
+    constructor(cause?: unknown);
+}
+declare class AfterHookExecutionError extends Error {
+    constructor(cause?: unknown);
+}
+declare class HandlerExecutionError extends Error {
+    constructor(cause?: unknown);
+}
+type ProtocolStage = "ApiCall" | "ApiInvoke" | "ApiResult" | "ApiHandlerResponse";
+declare class ProtocolError extends Error {
+    readonly source: "local_parse" | "remote";
+    readonly protocolStage?: ProtocolStage | undefined;
+    readonly correlationId?: string | undefined;
+    constructor(message: string, source: "local_parse" | "remote", protocolStage?: ProtocolStage | undefined, correlationId?: string | undefined);
+}
+type CancelledResult = {
+    readonly cancelled: true;
+    readonly reason: "ADDON_NOT_FOUND" | "ADDON_INACTIVE" | "ADDON_UNRESOLVED" | "CANCELLED_BY_HOOK";
+};
 
 interface Subscribable<T> {
     subscribe(fn: (arg: T) => void): Disposable;
@@ -253,19 +291,37 @@ declare class KairoContext {
 }
 
 declare class KairoRouter {
-    readonly apiRegistry: KairoApiRegistry;
     readonly afterEvents: KairoAfterEvents<KairoEventMap>;
     readonly beforeEvents: KairoBeforeEvents<KairoEventMap>;
     private constructor();
     get currentTick(): number;
     get systemInfo(): KairoContext;
     clearRun(runId: number): void;
+    getAddonId(): string | undefined;
+    getHookDeclarations(): readonly InternalHookDeclaration[];
+    send(targetAddonId: string, apiName: string, args?: unknown): void;
+    request<TReturn>(targetAddonId: string, apiName: string, args?: unknown, options?: {
+        timeout?: number;
+    }): Promise<TReturn | CancelledResult>;
     init(properties: AddonProperties): void;
     waitForWorldLoad(): Promise<void>;
     runInterval(callback: () => void, tickInterval?: number): number;
     runTimeout(callback: () => void, tickDelay?: number): number;
 }
 
+declare const ApiManifestSchema: _sinclair_typebox.TObject<{
+    apis: _sinclair_typebox.TArray<_sinclair_typebox.TObject<{
+        name: _sinclair_typebox.TString;
+    }>>;
+    hooks: _sinclair_typebox.TArray<_sinclair_typebox.TObject<{
+        targetAddonId: _sinclair_typebox.TString;
+        apiName: _sinclair_typebox.TString;
+        priority: _sinclair_typebox.TInteger;
+        phases: _sinclair_typebox.TArray<_sinclair_typebox.TUnion<[_sinclair_typebox.TLiteral<"before">, _sinclair_typebox.TLiteral<"after">]>>;
+    }>>;
+}>;
+type ApiManifest = Static<typeof ApiManifestSchema>;
+
 declare const router: KairoRouter;
 
-export { AddonActivateAfterEvent, AddonDeactivateBeforeEvent, type AfterHookContext, type BeforeHookContext, type Disposable, type HookOptions, type HookRollbackContext, KairoContext, KairoCustomCommandRegistry, type KairoRegistry, KairoRouter, KairoStartupBeforeEvent, router };
+export { AddonActivateAfterEvent, AddonDeactivateBeforeEvent, type AfterHookContext, AfterHookExecutionError, type ApiManifest, ApiNotFoundError, type BeforeHookContext, BeforeHookExecutionError, type CancelledResult, type DeepReadonly, type Disposable, HandlerExecutionError, type HookOptions, type HookRollbackContext, type InternalHookDeclaration, KairoContext, KairoCustomCommandRegistry, type KairoRegistry, KairoRouter, KairoStartupBeforeEvent, ProtocolError, type ProtocolStage, RequestTimeoutError, router };

--- a/lib/index.js
+++ b/lib/index.js
@@ -175,11 +175,282 @@ var KairoRuntime = class {
 // src/router/KairoRouter.ts
 import { SeedRandom as SeedRandom2 } from "@kairo-js/utils";
 
+// src/router/api/ApiCallSender.ts
+import { compile, safeJsonParse } from "@kairo-js/utils";
+
+// src/router/api/errors.ts
+var ApiNotFoundError = class extends Error {
+  constructor(apiName) {
+    super(apiName ? `API "${apiName}" not found` : "API not found");
+    this.name = "ApiNotFoundError";
+  }
+};
+var RequestTimeoutError = class extends Error {
+  constructor() {
+    super("Request timed out");
+    this.name = "RequestTimeoutError";
+  }
+};
+var BeforeHookExecutionError = class extends Error {
+  constructor(cause) {
+    super("Before hook threw an error");
+    this.name = "BeforeHookExecutionError";
+    if (cause !== void 0) this.cause = cause;
+  }
+};
+var AfterHookExecutionError = class extends Error {
+  constructor(cause) {
+    super("After hook threw an error");
+    this.name = "AfterHookExecutionError";
+    if (cause !== void 0) this.cause = cause;
+  }
+};
+var HandlerExecutionError = class extends Error {
+  constructor(cause) {
+    super("Handler threw an error");
+    this.name = "HandlerExecutionError";
+    if (cause !== void 0) this.cause = cause;
+  }
+};
+var ProtocolError = class extends Error {
+  constructor(message, source, protocolStage, correlationId) {
+    super(message);
+    this.source = source;
+    this.protocolStage = protocolStage;
+    this.correlationId = correlationId;
+    this.name = "ProtocolError";
+  }
+};
+
+// src/router/api/protocol/schema.ts
+import { Type } from "@sinclair/typebox";
+var ApiCallSchema = Type.Object(
+  {
+    type: Type.Union([Type.Literal("send"), Type.Literal("request")]),
+    correlationId: Type.String(),
+    targetAddonId: Type.String(),
+    apiName: Type.String(),
+    args: Type.String(),
+    timeout: Type.Optional(Type.Integer({ minimum: 1 })),
+    timestamp: Type.Integer({ minimum: 0 })
+  },
+  { additionalProperties: false }
+);
+var ApiInvokeSchema = Type.Object(
+  {
+    type: Type.Union([Type.Literal("send"), Type.Literal("request")]),
+    correlationId: Type.String(),
+    callerAddonId: Type.String(),
+    apiName: Type.String(),
+    args: Type.String(),
+    timestamp: Type.Integer({ minimum: 0 })
+  },
+  { additionalProperties: false }
+);
+var ApiHandlerResponseSchema = Type.Object(
+  {
+    correlationId: Type.String(),
+    success: Type.Boolean(),
+    result: Type.Optional(Type.String()),
+    error: Type.Optional(Type.String()),
+    timestamp: Type.Integer({ minimum: 0 })
+  },
+  { additionalProperties: false }
+);
+var ApiResultSchema = Type.Object(
+  {
+    correlationId: Type.String(),
+    success: Type.Boolean(),
+    result: Type.Optional(Type.String()),
+    cancelled: Type.Optional(Type.Literal(true)),
+    reason: Type.Optional(Type.String()),
+    errorType: Type.Optional(
+      Type.Union([
+        Type.Literal("API_NOT_FOUND"),
+        Type.Literal("BEFORE_HOOK_EXECUTION"),
+        Type.Literal("AFTER_HOOK_EXECUTION"),
+        Type.Literal("HANDLER_EXECUTION"),
+        Type.Literal("TIMEOUT"),
+        Type.Literal("PROTOCOL_ERROR")
+      ])
+    ),
+    error: Type.Optional(Type.String()),
+    timestamp: Type.Integer({ minimum: 0 })
+  },
+  { additionalProperties: false }
+);
+var ApiManifestSchema = Type.Object(
+  {
+    apis: Type.Array(Type.Object({ name: Type.String() })),
+    hooks: Type.Array(
+      Type.Object({
+        targetAddonId: Type.String(),
+        apiName: Type.String(),
+        priority: Type.Integer({ minimum: -2147483648, maximum: 2147483647 }),
+        phases: Type.Array(
+          Type.Union([Type.Literal("before"), Type.Literal("after")])
+        )
+      })
+    )
+  },
+  { additionalProperties: false }
+);
+
+// src/router/api/ApiCallSender.ts
+var DEFAULT_TIMEOUT_TICKS = 20;
+var SAFETY_MARGIN_TICKS = 5;
+var ApiCallSender = class {
+  constructor(runtime, getCallerKairoId) {
+    this.runtime = runtime;
+    this.getCallerKairoId = getCallerKairoId;
+    this.sessionId = Math.random().toString(36).slice(2, 8);
+  }
+  pendingRequests = /* @__PURE__ */ new Map();
+  sessionId;
+  counter = 0;
+  resultListener;
+  disposed = false;
+  setup() {
+    this.resultListener = this.runtime.receive((id, message) => {
+      if (!id.endsWith(":api-result")) return;
+      const correlationId = id.slice(0, -":api-result".length);
+      if (!this.pendingRequests.has(correlationId)) return;
+      this.handleApiResult(correlationId, message);
+    });
+  }
+  send(targetAddonId, apiName, args) {
+    const call = {
+      type: "send",
+      correlationId: "",
+      targetAddonId,
+      apiName,
+      args: JSON.stringify(args ?? null),
+      timestamp: this.runtime.currentTick()
+    };
+    try {
+      this.runtime.send("kairo:api-call", JSON.stringify(call));
+    } catch {
+    }
+  }
+  request(targetAddonId, apiName, args, options) {
+    const correlationId = `kjs-${this.sessionId}-${this.counter++}`;
+    const timeoutTicks = options?.timeout ?? DEFAULT_TIMEOUT_TICKS;
+    const call = {
+      type: "request",
+      correlationId,
+      targetAddonId,
+      apiName,
+      args: JSON.stringify(args ?? null),
+      timeout: timeoutTicks,
+      timestamp: this.runtime.currentTick()
+    };
+    return new Promise((resolve, reject) => {
+      const safetyTimeoutMs = (timeoutTicks + SAFETY_MARGIN_TICKS) * 50;
+      const safetyCleanupId = this.runtime.scheduler.runTimeout(() => {
+        const pending = this.pendingRequests.get(correlationId);
+        if (pending) {
+          this.pendingRequests.delete(correlationId);
+        }
+      }, timeoutTicks + SAFETY_MARGIN_TICKS);
+      this.pendingRequests.set(correlationId, {
+        resolve,
+        reject,
+        safetyCleanupId
+      });
+      try {
+        this.runtime.send("kairo:api-call", JSON.stringify(call));
+      } catch (e) {
+        this.pendingRequests.delete(correlationId);
+        this.runtime.scheduler.clearRun(safetyCleanupId);
+        reject(new ProtocolError("Failed to send ApiCall", "local_parse", "ApiCall", correlationId));
+      }
+    });
+  }
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    for (const [, pending] of this.pendingRequests) {
+      if (pending.safetyCleanupId !== void 0) {
+        this.runtime.scheduler.clearRun(pending.safetyCleanupId);
+      }
+    }
+    this.pendingRequests.clear();
+    this.resultListener?.dispose();
+    this.resultListener = void 0;
+  }
+  handleApiResult(correlationId, message) {
+    const pending = this.pendingRequests.get(correlationId);
+    if (!pending) return;
+    this.pendingRequests.delete(correlationId);
+    if (pending.safetyCleanupId !== void 0) {
+      this.runtime.scheduler.clearRun(pending.safetyCleanupId);
+    }
+    let result;
+    try {
+      const parsed = safeJsonParse(message, () => new Error("parse failed"));
+      if (!validateApiResult(parsed)) {
+        throw new ProtocolError(
+          "Invalid ApiResult schema",
+          "local_parse",
+          "ApiResult",
+          correlationId
+        );
+      }
+      result = parsed;
+    } catch (e) {
+      pending.reject(
+        e instanceof ProtocolError ? e : new ProtocolError("Failed to parse ApiResult", "local_parse", "ApiResult", correlationId)
+      );
+      return;
+    }
+    if (result.success) {
+      try {
+        const value = result.result !== void 0 ? JSON.parse(result.result) : void 0;
+        pending.resolve(value);
+      } catch {
+        pending.reject(new ProtocolError("Failed to parse ApiResult.result", "local_parse", "ApiResult", correlationId));
+      }
+      return;
+    }
+    if (result.cancelled) {
+      pending.resolve({
+        cancelled: true,
+        reason: result.reason
+      });
+      return;
+    }
+    switch (result.errorType) {
+      case "API_NOT_FOUND":
+        pending.reject(new ApiNotFoundError());
+        break;
+      case "BEFORE_HOOK_EXECUTION":
+        pending.reject(new BeforeHookExecutionError(result.error));
+        break;
+      case "AFTER_HOOK_EXECUTION":
+        pending.reject(new AfterHookExecutionError(result.error));
+        break;
+      case "HANDLER_EXECUTION":
+        pending.reject(new HandlerExecutionError(result.error));
+        break;
+      case "TIMEOUT":
+        pending.reject(new RequestTimeoutError());
+        break;
+      case "PROTOCOL_ERROR":
+        pending.reject(new ProtocolError(result.error ?? "Remote protocol error", "remote", "ApiResult", correlationId));
+        break;
+      default:
+        pending.reject(new ProtocolError("Unknown error type", "remote", "ApiResult", correlationId));
+    }
+  }
+};
+var validateApiResult = compile(ApiResultSchema);
+
 // src/router/api/KairoApiRegistry.ts
 var KairoApiRegistry = class {
   sealed = false;
   apiHandlers = /* @__PURE__ */ new Map();
   hookDeclarations = [];
+  sequenceCounter = 0;
   register(apiName, handler) {
     this.assertNotSealed();
     if (this.apiHandlers.has(apiName)) {
@@ -192,11 +463,13 @@ var KairoApiRegistry = class {
     if (!options.before && !options.after) {
       throw new Error("[kairo-router] hook must have at least one of before or after");
     }
+    const modes = options.modes ?? (options.after ? ["request"] : ["send", "request"]);
     this.hookDeclarations.push({
       targetAddonId,
       apiName,
       priority: options.priority ?? 0,
-      version: options.version,
+      modes,
+      sequence: this.sequenceCounter++,
       before: options.before,
       after: options.after,
       rollback: options.rollback
@@ -205,8 +478,18 @@ var KairoApiRegistry = class {
   seal() {
     this.sealed = true;
   }
-  getApiHandlers() {
-    return this.apiHandlers;
+  setDeclaringAddonId(addonId) {
+    for (const decl of this.hookDeclarations) {
+      if (!decl.declaringAddonId) {
+        decl.declaringAddonId = addonId;
+      }
+    }
+  }
+  getApiHandler(apiName) {
+    return this.apiHandlers.get(apiName);
+  }
+  getApiNames() {
+    return [...this.apiHandlers.keys()];
   }
   getHookDeclarations() {
     return this.hookDeclarations;
@@ -216,10 +499,112 @@ var KairoApiRegistry = class {
   }
   assertNotSealed() {
     if (this.sealed) {
-      throw new Error("[kairo-router] API registration is only allowed during the startup event");
+      throw new Error(
+        "[kairo-router] API registration is only allowed during the startup event"
+      );
     }
   }
 };
+
+// src/router/api/InvokeHandler.ts
+import { compile as compile2, safeJsonParse as safeJsonParse2 } from "@kairo-js/utils";
+var InvokeHandler = class {
+  constructor(runtime, apiRegistry, getKairoKairoId, getOwnKairoId) {
+    this.runtime = runtime;
+    this.apiRegistry = apiRegistry;
+    this.getKairoKairoId = getKairoKairoId;
+    this.getOwnKairoId = getOwnKairoId;
+  }
+  listener;
+  disposed = false;
+  setup() {
+    const ownKairoId = this.getOwnKairoId();
+    this.listener = this.runtime.receive((id, message) => {
+      if (id !== `${ownKairoId}:api-invoke`) return;
+      void this.handleInvoke(message);
+    });
+  }
+  dispose() {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.listener?.dispose();
+    this.listener = void 0;
+  }
+  async handleInvoke(message) {
+    let invoke;
+    try {
+      const parsed = safeJsonParse2(message, () => new Error("parse failed"));
+      if (!validateApiInvoke(parsed)) {
+        console.warn("[kairo-router] InvokeHandler: invalid ApiInvoke schema");
+        return;
+      }
+      invoke = parsed;
+    } catch {
+      console.warn("[kairo-router] InvokeHandler: failed to parse ApiInvoke");
+      return;
+    }
+    if (invoke.type === "send") {
+      await this.executeHandler(invoke, false);
+    } else {
+      await this.executeHandler(invoke, true);
+    }
+  }
+  async executeHandler(invoke, sendResponse) {
+    const handler = this.apiRegistry.getApiHandler(invoke.apiName);
+    if (!handler) {
+      if (sendResponse) {
+        this.sendHandlerResponse(invoke.correlationId, false, void 0, `Handler for "${invoke.apiName}" not found`);
+      }
+      return;
+    }
+    let args;
+    try {
+      args = JSON.parse(invoke.args);
+    } catch {
+      if (sendResponse) {
+        this.sendHandlerResponse(invoke.correlationId, false, void 0, "Failed to parse args");
+      }
+      return;
+    }
+    let result;
+    try {
+      result = await handler(args);
+    } catch (e) {
+      if (sendResponse) {
+        const message = e instanceof Error ? e.message : String(e);
+        this.sendHandlerResponse(invoke.correlationId, false, void 0, message);
+      } else {
+        console.warn("[kairo-router] InvokeHandler: handler threw (send mode):", e);
+      }
+      return;
+    }
+    if (!sendResponse) return;
+    let resultStr;
+    try {
+      resultStr = JSON.stringify(result);
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "Result is not JSON serializable";
+      this.sendHandlerResponse(invoke.correlationId, false, void 0, message);
+      return;
+    }
+    this.sendHandlerResponse(invoke.correlationId, true, resultStr, void 0);
+  }
+  sendHandlerResponse(correlationId, success, result, error) {
+    const response = {
+      correlationId,
+      success,
+      ...result !== void 0 ? { result } : {},
+      ...error !== void 0 ? { error } : {},
+      timestamp: this.runtime.currentTick()
+    };
+    try {
+      this.runtime.send("kairo:api-response", JSON.stringify(response));
+    } catch (e) {
+      console.warn("[kairo-router] InvokeHandler: failed to send ApiHandlerResponse:", e);
+    }
+  }
+};
+var validateApiInvoke = compile2(ApiInvokeSchema);
 
 // src/router/events/classes/AddonActivateAfterEvent.ts
 var AddonActivateAfterEvent = class {
@@ -501,14 +886,14 @@ var DEFAULT_MESSAGES4 = {
 import fastJson from "fast-json-stringify";
 
 // src/router/activation/response/schema.ts
-import { Type } from "@sinclair/typebox";
-var ActivationResponseSchema = Type.Object(
+import { Type as Type2 } from "@sinclair/typebox";
+var ActivationResponseSchema = Type2.Object(
   {
-    timestamp: Type.Integer({ minimum: 0 }),
-    kairoId: Type.String(),
-    status: Type.Union([Type.Literal("success"), Type.Literal("failure")]),
-    action: Type.Union([Type.Literal("activate"), Type.Literal("deactivate")]),
-    reason: Type.Optional(Type.String())
+    timestamp: Type2.Integer({ minimum: 0 }),
+    kairoId: Type2.String(),
+    status: Type2.Union([Type2.Literal("success"), Type2.Literal("failure")]),
+    action: Type2.Union([Type2.Literal("activate"), Type2.Literal("deactivate")]),
+    reason: Type2.Optional(Type2.String())
   },
   { additionalProperties: false }
 );
@@ -540,7 +925,7 @@ var ActivationResponder = class {
 };
 
 // src/router/activation/ActivationRequestParser.ts
-import { safeJsonParse, toError as toError2 } from "@kairo-js/utils";
+import { safeJsonParse as safeJsonParse3, toError as toError2 } from "@kairo-js/utils";
 
 // src/router/activation/request/errors.ts
 var ActivationRequestParseError = class extends Error {
@@ -573,22 +958,22 @@ var REQUEST_DEFAULT_MESSAGES = {
 };
 
 // src/router/activation/request/validate.ts
-import { compile } from "@kairo-js/utils";
+import { compile as compile3 } from "@kairo-js/utils";
 
 // src/router/activation/request/schema.ts
-import { Type as Type2 } from "@sinclair/typebox";
-var ActivationRequestSchema = Type2.Object({
-  timestamp: Type2.Integer({ minimum: 0 }),
-  action: Type2.Union([Type2.Literal("activate"), Type2.Literal("deactivate")])
+import { Type as Type3 } from "@sinclair/typebox";
+var ActivationRequestSchema = Type3.Object({
+  timestamp: Type3.Integer({ minimum: 0 }),
+  action: Type3.Union([Type3.Literal("activate"), Type3.Literal("deactivate")])
 });
 
 // src/router/activation/request/validate.ts
-var validateActivationRequest = compile(ActivationRequestSchema);
+var validateActivationRequest = compile3(ActivationRequestSchema);
 
 // src/router/activation/ActivationRequestParser.ts
 var ActivationRequestParser = class {
   parse(message) {
-    const parsed = safeJsonParse(
+    const parsed = safeJsonParse3(
       message,
       () => new ActivationRequestParseError("InvalidJSON" /* InvalidJSON */)
     );
@@ -1001,7 +1386,7 @@ var KairoIdProvider = class {
 };
 
 // src/router/init/discovery/DiscoveryQueryParser.ts
-import { safeJsonParse as safeJsonParse2, toError as toError3 } from "@kairo-js/utils";
+import { safeJsonParse as safeJsonParse4, toError as toError3 } from "@kairo-js/utils";
 
 // src/router/init/discovery/query/errors.ts
 var DiscoveryQueryParseError = class extends Error {
@@ -1032,14 +1417,14 @@ var QUERY_DEFAULT_MESSAGES = {
 };
 
 // src/router/init/discovery/query/validate.ts
-import { compile as compile2 } from "@kairo-js/utils";
+import { compile as compile4 } from "@kairo-js/utils";
 
 // src/router/init/discovery/query/schema.ts
-import { Type as Type3 } from "@sinclair/typebox";
-var DiscoveryQuerySchema = Type3.Object(
+import { Type as Type4 } from "@sinclair/typebox";
+var DiscoveryQuerySchema = Type4.Object(
   {
-    timestamp: Type3.Integer({ minimum: 0 }),
-    registryId: Type3.String()
+    timestamp: Type4.Integer({ minimum: 0 }),
+    registryId: Type4.String()
   },
   {
     additionalProperties: false
@@ -1047,14 +1432,14 @@ var DiscoveryQuerySchema = Type3.Object(
 );
 
 // src/router/init/discovery/query/validate.ts
-var validateDiscoveryQuery = compile2(DiscoveryQuerySchema);
+var validateDiscoveryQuery = compile4(DiscoveryQuerySchema);
 
 // src/router/init/discovery/DiscoveryQueryParser.ts
 var DiscoveryQueryParser = class {
   constructor() {
   }
   parse(message) {
-    const parsed = safeJsonParse2(
+    const parsed = safeJsonParse4(
       message,
       () => new DiscoveryQueryParseError("InvalidJSON" /* InvalidJSON */)
     );
@@ -1122,11 +1507,11 @@ var DEFAULT_MESSAGES7 = {
 import fastJson2 from "fast-json-stringify";
 
 // src/router/init/discovery/response/schema.ts
-import { Type as Type4 } from "@sinclair/typebox";
-var DiscoveryResponseSchema = Type4.Object(
+import { Type as Type5 } from "@sinclair/typebox";
+var DiscoveryResponseSchema = Type5.Object(
   {
-    kairoId: Type4.String(),
-    timestamp: Type4.Integer({ minimum: 0 })
+    kairoId: Type5.String(),
+    timestamp: Type5.Integer({ minimum: 0 })
   },
   { additionalProperties: false }
 );
@@ -1211,7 +1596,7 @@ var KairoRegistryBuilder = class {
 };
 
 // src/router/init/registration/RegistrationRequestParser.ts
-import { safeJsonParse as safeJsonParse3, toError as toError5 } from "@kairo-js/utils";
+import { safeJsonParse as safeJsonParse5, toError as toError5 } from "@kairo-js/utils";
 
 // src/router/init/registration/request/errors.ts
 var RegistrationRequestParseError = class extends Error {
@@ -1242,15 +1627,15 @@ var REQUEST_DEFAULT_MESSAGES2 = {
 };
 
 // src/router/init/registration/request/validate.ts
-import { compile as compile3 } from "@kairo-js/utils";
+import { compile as compile5 } from "@kairo-js/utils";
 
 // src/router/init/registration/request/schema.ts
-import { Type as Type5 } from "@sinclair/typebox";
-var RegistrationRequestSchema = Type5.Object(
+import { Type as Type6 } from "@sinclair/typebox";
+var RegistrationRequestSchema = Type6.Object(
   {
-    approvals: Type5.Array(Type5.String()),
-    rejects: Type5.Array(Type5.String()),
-    timestamp: Type5.Integer({ minimum: 0 })
+    approvals: Type6.Array(Type6.String()),
+    rejects: Type6.Array(Type6.String()),
+    timestamp: Type6.Integer({ minimum: 0 })
   },
   {
     additionalProperties: false
@@ -1258,12 +1643,12 @@ var RegistrationRequestSchema = Type5.Object(
 );
 
 // src/router/init/registration/request/validate.ts
-var validateRegistrationRequest = compile3(RegistrationRequestSchema);
+var validateRegistrationRequest = compile5(RegistrationRequestSchema);
 
 // src/router/init/registration/RegistrationRequestParser.ts
 var RegistrationRequestParser = class {
   parse(message) {
-    const parsed = safeJsonParse3(
+    const parsed = safeJsonParse5(
       message,
       () => new RegistrationRequestParseError("InvalidJSON" /* InvalidJSON */)
     );
@@ -1297,7 +1682,7 @@ var RegistrationRequestValidator = class {
 };
 
 // src/router/init/registration/RegistrationResultParser.ts
-import { safeJsonParse as safeJsonParse4, toError as toError6 } from "@kairo-js/utils";
+import { safeJsonParse as safeJsonParse6, toError as toError6 } from "@kairo-js/utils";
 
 // src/router/init/registration/result/errors.ts
 var RegistrationResultParseError = class extends Error {
@@ -1328,16 +1713,16 @@ var RESULT_DEFAULT_MESSAGES = {
 };
 
 // src/router/init/registration/result/validate.ts
-import { compile as compile4 } from "@kairo-js/utils";
+import { compile as compile6 } from "@kairo-js/utils";
 
 // src/router/init/registration/result/schema.ts
-import { Type as Type6 } from "@sinclair/typebox";
-var RegistrationResultSchema = Type6.Object(
+import { Type as Type7 } from "@sinclair/typebox";
+var RegistrationResultSchema = Type7.Object(
   {
-    kairoId: Type6.String(),
-    success: Type6.Boolean(),
-    reason: Type6.Optional(Type6.String()),
-    timestamp: Type6.Integer({ minimum: 0 })
+    kairoId: Type7.String(),
+    success: Type7.Boolean(),
+    reason: Type7.Optional(Type7.String()),
+    timestamp: Type7.Integer({ minimum: 0 })
   },
   {
     additionalProperties: false
@@ -1345,12 +1730,12 @@ var RegistrationResultSchema = Type6.Object(
 );
 
 // src/router/init/registration/result/validate.ts
-var validateRegistrationResult = compile4(RegistrationResultSchema);
+var validateRegistrationResult = compile6(RegistrationResultSchema);
 
 // src/router/init/registration/RegistrationResultParser.ts
 var RegistrationResultParser = class {
   parse(message) {
-    const parsed = safeJsonParse4(
+    const parsed = safeJsonParse6(
       message,
       () => new RegistrationResultParseError("InvalidJSON" /* InvalidJSON */)
     );
@@ -1414,6 +1799,25 @@ var AddonRegistrationManager = class {
 // src/router/init/registration/RegistrationResponder.ts
 import { toError as toError7 } from "@kairo-js/utils";
 
+// src/router/api/ApiManifestBuilder.ts
+var ApiManifestBuilder = class {
+  build(registry) {
+    const apis = registry.getApiNames().map((name) => ({ name }));
+    const hooks = registry.getHookDeclarations().map((decl) => {
+      const phases = [];
+      if (decl.before) phases.push("before");
+      if (decl.after) phases.push("after");
+      return {
+        targetAddonId: decl.targetAddonId,
+        apiName: decl.apiName,
+        priority: decl.priority,
+        phases
+      };
+    });
+    return { apis, hooks };
+  }
+};
+
 // src/router/init/registration/response/errors.ts
 var RegistrationResponseError = class extends Error {
   reason;
@@ -1432,35 +1836,48 @@ var DEFAULT_MESSAGES8 = {
 import fastJson3 from "fast-json-stringify";
 
 // src/router/init/registration/response/schema.ts
-import { Type as Type7 } from "@sinclair/typebox";
-var RegistrationResponseSchema = Type7.Object(
+import { Type as Type8 } from "@sinclair/typebox";
+var RegistrationResponseSchema = Type8.Object(
   {
-    kairoRegistry: Type7.Object({
-      kairoId: Type7.Readonly(Type7.String()),
-      addonId: Type7.Readonly(Type7.String()),
-      name: Type7.Readonly(Type7.String()),
-      description: Type7.Readonly(Type7.String()),
-      version: Type7.Readonly(
-        Type7.Object({
-          major: Type7.Number(),
-          minor: Type7.Number(),
-          patch: Type7.Number(),
-          prerelease: Type7.Optional(Type7.String()),
-          build: Type7.Optional(Type7.String())
+    kairoRegistry: Type8.Object({
+      kairoId: Type8.Readonly(Type8.String()),
+      addonId: Type8.Readonly(Type8.String()),
+      name: Type8.Readonly(Type8.String()),
+      description: Type8.Readonly(Type8.String()),
+      version: Type8.Readonly(
+        Type8.Object({
+          major: Type8.Number(),
+          minor: Type8.Number(),
+          patch: Type8.Number(),
+          prerelease: Type8.Optional(Type8.String()),
+          build: Type8.Optional(Type8.String())
         })
       ),
-      metadata: Type7.Readonly(
-        Type7.Object({
-          authors: Type7.Readonly(Type7.Array(Type7.String())),
-          url: Type7.Optional(Type7.String()),
-          license: Type7.Optional(Type7.String())
+      metadata: Type8.Readonly(
+        Type8.Object({
+          authors: Type8.Readonly(Type8.Array(Type8.String())),
+          url: Type8.Optional(Type8.String()),
+          license: Type8.Optional(Type8.String())
         })
       ),
-      dependencies: Type7.Readonly(Type7.Record(Type7.String(), Type7.String())),
-      optionalDependencies: Type7.Readonly(Type7.Record(Type7.String(), Type7.String())),
-      tags: Type7.Readonly(Type7.Array(Type7.String()))
+      dependencies: Type8.Readonly(Type8.Record(Type8.String(), Type8.String())),
+      optionalDependencies: Type8.Readonly(Type8.Record(Type8.String(), Type8.String())),
+      tags: Type8.Readonly(Type8.Array(Type8.String()))
     }),
-    timestamp: Type7.Integer({ minimum: 0 })
+    apiManifest: Type8.Object({
+      apis: Type8.Array(Type8.Object({ name: Type8.String() })),
+      hooks: Type8.Array(
+        Type8.Object({
+          targetAddonId: Type8.String(),
+          apiName: Type8.String(),
+          priority: Type8.Integer({ minimum: -2147483648, maximum: 2147483647 }),
+          phases: Type8.Array(
+            Type8.Union([Type8.Literal("before"), Type8.Literal("after")])
+          )
+        })
+      )
+    }),
+    timestamp: Type8.Integer({ minimum: 0 })
   },
   {
     additionalProperties: false
@@ -1474,11 +1891,12 @@ var stringifyRegistrationResponse = fastJson3(
 
 // src/router/init/registration/RegistrationResponder.ts
 var RegistrationResponder = class {
-  constructor() {
-  }
-  respond(runtime, kairoRegistry) {
+  manifestBuilder = new ApiManifestBuilder();
+  respond(runtime, kairoRegistry, apiRegistry) {
+    const apiManifest = this.manifestBuilder.build(apiRegistry);
     const response = {
       kairoRegistry,
+      apiManifest,
       timestamp: runtime.currentTick()
     };
     try {
@@ -1494,8 +1912,9 @@ var RegistrationResponder = class {
 
 // src/router/init/registration/RegistrationController.ts
 var RegistrationController = class {
-  constructor(registryBuilder) {
+  constructor(registryBuilder, apiRegistry) {
     this.registryBuilder = registryBuilder;
+    this.apiRegistry = apiRegistry;
     this.registrationManager = new AddonRegistrationManager(this.registryBuilder);
     this.registrationResponder = new RegistrationResponder();
   }
@@ -1509,8 +1928,9 @@ var RegistrationController = class {
       deps.context.addonProperties
     );
     if (!registry) return;
-    this.registrationResponder.respond(deps.runtime, registry);
+    this.registrationResponder.respond(deps.runtime, registry, this.apiRegistry);
     deps.contextMutator.setKairoRegistry(registry);
+    this.apiRegistry.setDeclaringAddonId(registry.addonId);
     return registry;
   };
   handleRegistrationResult = (message, deps) => {
@@ -1520,18 +1940,19 @@ var RegistrationController = class {
 
 // src/router/init/KairoInitializer.ts
 var KairoInitializer = class {
-  constructor(runtime, context, contextMutator, random, readyState, onCompleted, onDisposed) {
+  constructor(runtime, context, contextMutator, random, readyState, apiRegistry, onCompleted, onDisposed) {
     this.runtime = runtime;
     this.context = context;
     this.contextMutator = contextMutator;
     this.random = random;
     this.readyState = readyState;
+    this.apiRegistry = apiRegistry;
     this.onCompleted = onCompleted;
     this.onDisposed = onDisposed;
     this.idProvider = new KairoIdProvider(this.random);
     this.registryBuilder = new KairoRegistryBuilder();
     this.discoveryController = new DiscoveryController(this.idProvider);
-    this.registrationController = new RegistrationController(this.registryBuilder);
+    this.registrationController = new RegistrationController(this.registryBuilder, this.apiRegistry);
     this.initListener = new KairoInitListener(this.readyState, {
       ["kairo:discovery_query" /* DiscoveryQuery */]: this.handleDiscoveryQuery,
       ["kairo:registration_request" /* RegistrationRequest */]: this.handleRegistrationRequest,
@@ -1680,6 +2101,8 @@ var KairoRouter = class {
   initializer;
   disposed = false;
   startupSubscription;
+  apiCallSender;
+  invokeHandler;
   apiRegistry = new KairoApiRegistry();
   startupEvent = new InternalEvent(
     () => this.kairoContext?.isActive() ?? false,
@@ -1717,6 +2140,20 @@ var KairoRouter = class {
     this.assertRunnable();
     this.scheduler.clearRun(runId);
   }
+  getAddonId() {
+    return this.kairoContext?.addonProperties.id;
+  }
+  getHookDeclarations() {
+    return this.apiRegistry.getHookDeclarations();
+  }
+  send(targetAddonId, apiName, args) {
+    this.assertRunnable();
+    this.apiCallSender.send(targetAddonId, apiName, args);
+  }
+  request(targetAddonId, apiName, args, options) {
+    this.assertRunnable();
+    return this.apiCallSender.request(targetAddonId, apiName, args, options);
+  }
   init(properties) {
     this.assertNotDisposed();
     if (this.kairoContext) {
@@ -1734,6 +2171,7 @@ var KairoRouter = class {
       mutator,
       new SeedRandom2(),
       this.readyState,
+      this.apiRegistry,
       () => {
         this.initializer = void 0;
         this.startRouterListener();
@@ -1773,6 +2211,10 @@ var KairoRouter = class {
     this.routerListener = void 0;
     this.worldLoadListener?.dispose();
     this.worldLoadListener = void 0;
+    this.apiCallSender?.dispose();
+    this.apiCallSender = void 0;
+    this.invokeHandler?.dispose();
+    this.invokeHandler = void 0;
     this.eventRegistry.clearActiveScopedListeners();
     this.kairoContextMutator?.setActivationState("inactive");
     this.scheduler?.setActive(false);
@@ -1798,6 +2240,16 @@ var KairoRouter = class {
     if (this.routerListener) {
       throw new KairoRouterInitError("AlreadyInitialized" /* AlreadyInitialized */);
     }
+    const runtime = this.runtime;
+    const context = this.kairoContext;
+    this.apiCallSender = new ApiCallSender(runtime, () => context.kairoId);
+    this.apiCallSender.setup();
+    this.invokeHandler = new InvokeHandler(
+      runtime,
+      this.apiRegistry,
+      () => "kairo",
+      () => context.kairoId
+    );
     const activationController = new ActivationController(
       this.runtime,
       this.kairoContext,
@@ -1809,12 +2261,20 @@ var KairoRouter = class {
           this.startActivationTickCounter();
           this.attachRuntimeEvents();
           this.scheduler?.setActive(true);
+          this.invokeHandler.setup();
         },
         onDeactivate: () => {
           this.stopActivationTickCounter();
           this.eventRegistry.clearActiveScopedListeners();
           this.detachRuntimeEvents();
           this.scheduler?.setActive(false);
+          this.invokeHandler?.dispose();
+          this.invokeHandler = new InvokeHandler(
+            runtime,
+            this.apiRegistry,
+            () => "kairo",
+            () => context.kairoId
+          );
         }
       }
     );
@@ -1878,9 +2338,15 @@ var router = new KairoRouter();
 export {
   AddonActivateAfterEvent,
   AddonDeactivateBeforeEvent,
+  AfterHookExecutionError,
+  ApiNotFoundError,
+  BeforeHookExecutionError,
+  HandlerExecutionError,
   KairoContext,
   KairoCustomCommandRegistry,
   KairoRouter,
   KairoStartupBeforeEvent,
+  ProtocolError,
+  RequestTimeoutError,
   router
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kairo-js/router",
-    "version": "0.2.0-beta.27",
+    "version": "0.3.0-beta.0",
     "description": "Router module for Kairo.js",
     "type": "module",
     "license": "MIT",

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,25 @@ export { AddonDeactivateBeforeEvent } from "./router/events/classes/AddonDeactiv
 export { KairoCustomCommandRegistry } from "./router/events/classes/KairoCustomCommandRegistry";
 export { KairoStartupBeforeEvent } from "./router/events/classes/KairoStartupBeforeEvent";
 
-export type { BeforeHookContext, AfterHookContext, HookRollbackContext, HookOptions } from "./router/api/KairoApiRegistry";
+export type {
+    BeforeHookContext,
+    AfterHookContext,
+    HookRollbackContext,
+    HookOptions,
+    DeepReadonly,
+    InternalHookDeclaration,
+} from "./router/api/KairoApiRegistry";
+
+export {
+    ApiNotFoundError,
+    RequestTimeoutError,
+    BeforeHookExecutionError,
+    AfterHookExecutionError,
+    HandlerExecutionError,
+    ProtocolError,
+} from "./router/api/errors";
+export type { CancelledResult, ProtocolStage } from "./router/api/errors";
+
+export type { ApiManifest } from "./router/api/protocol/schema";
 
 export type { Disposable } from "./router/types/Disposable";

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -34,7 +34,7 @@ export class KairoRouter {
     private disposed = false;
     private startupSubscription?: Disposable;
 
-    readonly apiRegistry = new KairoApiRegistry();
+    private readonly apiRegistry = new KairoApiRegistry();
 
     private readonly startupEvent = new InternalEvent<KairoStartupBeforeEvent>(
         () => this.kairoContext?.isActive() ?? false,

--- a/src/router/KairoRouter.ts
+++ b/src/router/KairoRouter.ts
@@ -3,7 +3,10 @@ import { KairoRuntime } from "../minecraft/KairoRuntime";
 import type { AddonProperties } from "@kairo-js/properties";
 import { SeedRandom } from "@kairo-js/utils";
 import type { KairoEventMap } from "../minecraft/KairoEventMap";
+import { ApiCallSender } from "./api/ApiCallSender";
 import { KairoApiRegistry } from "./api/KairoApiRegistry";
+import { InvokeHandler } from "./api/InvokeHandler";
+import type { CancelledResult } from "./api/errors";
 import { ActivationController } from "./activation/ActivationController";
 import { KairoRouterError, KairoRouterErrorReason } from "./errors/KairoRouterError";
 import { EventRegistry } from "./events/EventRegistry";
@@ -33,6 +36,9 @@ export class KairoRouter {
     private initializer?: Disposable;
     private disposed = false;
     private startupSubscription?: Disposable;
+
+    private apiCallSender?: ApiCallSender;
+    private invokeHandler?: InvokeHandler;
 
     private readonly apiRegistry = new KairoApiRegistry();
 
@@ -81,6 +87,29 @@ export class KairoRouter {
         this.scheduler!.clearRun(runId);
     }
 
+    getAddonId(): string | undefined {
+        return this.kairoContext?.addonProperties.id;
+    }
+
+    getHookDeclarations(): readonly import("./api/KairoApiRegistry").InternalHookDeclaration[] {
+        return this.apiRegistry.getHookDeclarations();
+    }
+
+    send(targetAddonId: string, apiName: string, args?: unknown): void {
+        this.assertRunnable();
+        this.apiCallSender!.send(targetAddonId, apiName, args);
+    }
+
+    request<TReturn>(
+        targetAddonId: string,
+        apiName: string,
+        args?: unknown,
+        options?: { timeout?: number },
+    ): Promise<TReturn | CancelledResult> {
+        this.assertRunnable();
+        return this.apiCallSender!.request<TReturn>(targetAddonId, apiName, args, options);
+    }
+
     init(properties: AddonProperties): void {
         this.assertNotDisposed();
 
@@ -103,6 +132,7 @@ export class KairoRouter {
             mutator,
             new SeedRandom(),
             this.readyState,
+            this.apiRegistry,
             () => {
                 this.initializer = undefined;
                 this.startRouterListener();
@@ -155,6 +185,12 @@ export class KairoRouter {
         this.worldLoadListener?.dispose();
         this.worldLoadListener = undefined;
 
+        this.apiCallSender?.dispose();
+        this.apiCallSender = undefined;
+
+        this.invokeHandler?.dispose();
+        this.invokeHandler = undefined;
+
         this.eventRegistry.clearActiveScopedListeners();
         this.kairoContextMutator?.setActivationState("inactive");
         this.scheduler?.setActive(false);
@@ -187,6 +223,19 @@ export class KairoRouter {
             throw new KairoRouterInitError(KairoRouterInitErrorReason.AlreadyInitialized);
         }
 
+        const runtime = this.runtime;
+        const context = this.kairoContext;
+
+        this.apiCallSender = new ApiCallSender(runtime, () => context.kairoId);
+        this.apiCallSender.setup();
+
+        this.invokeHandler = new InvokeHandler(
+            runtime,
+            this.apiRegistry,
+            () => "kairo",
+            () => context.kairoId,
+        );
+
         const activationController = new ActivationController(
             this.runtime,
             this.kairoContext,
@@ -198,12 +247,20 @@ export class KairoRouter {
                     this.startActivationTickCounter();
                     this.attachRuntimeEvents();
                     this.scheduler?.setActive(true);
+                    this.invokeHandler!.setup();
                 },
                 onDeactivate: () => {
                     this.stopActivationTickCounter();
                     this.eventRegistry.clearActiveScopedListeners();
                     this.detachRuntimeEvents();
                     this.scheduler?.setActive(false);
+                    this.invokeHandler?.dispose();
+                    this.invokeHandler = new InvokeHandler(
+                        runtime,
+                        this.apiRegistry,
+                        () => "kairo",
+                        () => context.kairoId,
+                    );
                 },
             },
         );

--- a/src/router/api/ApiCallSender.ts
+++ b/src/router/api/ApiCallSender.ts
@@ -1,0 +1,195 @@
+import { compile, safeJsonParse } from "@kairo-js/utils";
+import type { KairoRuntime } from "../../minecraft/KairoRuntime";
+import type { Disposable } from "../types/Disposable";
+import {
+    AfterHookExecutionError,
+    ApiNotFoundError,
+    BeforeHookExecutionError,
+    type CancelledResult,
+    HandlerExecutionError,
+    ProtocolError,
+    RequestTimeoutError,
+} from "./errors";
+import { ApiCallSchema, ApiResultSchema, type ApiCall, type ApiResult } from "./protocol/schema";
+
+const DEFAULT_TIMEOUT_TICKS = 20;
+const SAFETY_MARGIN_TICKS = 5;
+
+type PendingRequest = {
+    resolve: (result: unknown) => void;
+    reject: (error: unknown) => void;
+    safetyCleanupId?: number;
+};
+
+export class ApiCallSender implements Disposable {
+    private readonly pendingRequests = new Map<string, PendingRequest>();
+    private sessionId: string;
+    private counter = 0;
+    private resultListener?: Disposable;
+    private disposed = false;
+
+    constructor(
+        private readonly runtime: KairoRuntime,
+        private readonly getCallerKairoId: () => string,
+    ) {
+        this.sessionId = Math.random().toString(36).slice(2, 8);
+    }
+
+    setup(): void {
+        this.resultListener = this.runtime.receive((id, message) => {
+            if (!id.endsWith(":api-result")) return;
+            const correlationId = id.slice(0, -":api-result".length);
+            if (!this.pendingRequests.has(correlationId)) return;
+            this.handleApiResult(correlationId, message);
+        });
+    }
+
+    send(targetAddonId: string, apiName: string, args?: unknown): void {
+        const call: ApiCall = {
+            type: "send",
+            correlationId: "",
+            targetAddonId,
+            apiName,
+            args: JSON.stringify(args ?? null),
+            timestamp: this.runtime.currentTick(),
+        };
+        try {
+            this.runtime.send("kairo:api-call", JSON.stringify(call));
+        } catch {
+            // fire-and-forget: ignore errors
+        }
+    }
+
+    request<TReturn>(
+        targetAddonId: string,
+        apiName: string,
+        args?: unknown,
+        options?: { timeout?: number },
+    ): Promise<TReturn | CancelledResult> {
+        const correlationId = `kjs-${this.sessionId}-${this.counter++}`;
+        const timeoutTicks = options?.timeout ?? DEFAULT_TIMEOUT_TICKS;
+
+        const call: ApiCall = {
+            type: "request",
+            correlationId,
+            targetAddonId,
+            apiName,
+            args: JSON.stringify(args ?? null),
+            timeout: timeoutTicks,
+            timestamp: this.runtime.currentTick(),
+        };
+
+        return new Promise<TReturn | CancelledResult>((resolve, reject) => {
+            const safetyTimeoutMs = (timeoutTicks + SAFETY_MARGIN_TICKS) * 50;
+            const safetyCleanupId = this.runtime.scheduler.runTimeout(() => {
+                const pending = this.pendingRequests.get(correlationId);
+                if (pending) {
+                    this.pendingRequests.delete(correlationId);
+                }
+            }, timeoutTicks + SAFETY_MARGIN_TICKS);
+
+            this.pendingRequests.set(correlationId, {
+                resolve: resolve as (v: unknown) => void,
+                reject,
+                safetyCleanupId,
+            });
+
+            try {
+                this.runtime.send("kairo:api-call", JSON.stringify(call));
+            } catch (e) {
+                this.pendingRequests.delete(correlationId);
+                this.runtime.scheduler.clearRun(safetyCleanupId);
+                reject(new ProtocolError("Failed to send ApiCall", "local_parse", "ApiCall", correlationId));
+            }
+        });
+    }
+
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+
+        for (const [, pending] of this.pendingRequests) {
+            if (pending.safetyCleanupId !== undefined) {
+                this.runtime.scheduler.clearRun(pending.safetyCleanupId);
+            }
+        }
+        this.pendingRequests.clear();
+
+        this.resultListener?.dispose();
+        this.resultListener = undefined;
+    }
+
+    private handleApiResult(correlationId: string, message: string): void {
+        const pending = this.pendingRequests.get(correlationId);
+        if (!pending) return;
+
+        this.pendingRequests.delete(correlationId);
+        if (pending.safetyCleanupId !== undefined) {
+            this.runtime.scheduler.clearRun(pending.safetyCleanupId);
+        }
+
+        let result: ApiResult;
+        try {
+            const parsed = safeJsonParse(message, () => new Error("parse failed"));
+            if (!validateApiResult(parsed)) {
+                throw new ProtocolError(
+                    "Invalid ApiResult schema",
+                    "local_parse",
+                    "ApiResult",
+                    correlationId,
+                );
+            }
+            result = parsed as ApiResult;
+        } catch (e) {
+            pending.reject(
+                e instanceof ProtocolError
+                    ? e
+                    : new ProtocolError("Failed to parse ApiResult", "local_parse", "ApiResult", correlationId),
+            );
+            return;
+        }
+
+        if (result.success) {
+            try {
+                const value = result.result !== undefined ? JSON.parse(result.result) : undefined;
+                pending.resolve(value);
+            } catch {
+                pending.reject(new ProtocolError("Failed to parse ApiResult.result", "local_parse", "ApiResult", correlationId));
+            }
+            return;
+        }
+
+        if (result.cancelled) {
+            pending.resolve({
+                cancelled: true as const,
+                reason: result.reason as CancelledResult["reason"],
+            });
+            return;
+        }
+
+        switch (result.errorType) {
+            case "API_NOT_FOUND":
+                pending.reject(new ApiNotFoundError());
+                break;
+            case "BEFORE_HOOK_EXECUTION":
+                pending.reject(new BeforeHookExecutionError(result.error));
+                break;
+            case "AFTER_HOOK_EXECUTION":
+                pending.reject(new AfterHookExecutionError(result.error));
+                break;
+            case "HANDLER_EXECUTION":
+                pending.reject(new HandlerExecutionError(result.error));
+                break;
+            case "TIMEOUT":
+                pending.reject(new RequestTimeoutError());
+                break;
+            case "PROTOCOL_ERROR":
+                pending.reject(new ProtocolError(result.error ?? "Remote protocol error", "remote", "ApiResult", correlationId));
+                break;
+            default:
+                pending.reject(new ProtocolError("Unknown error type", "remote", "ApiResult", correlationId));
+        }
+    }
+}
+
+const validateApiResult = compile(ApiResultSchema);

--- a/src/router/api/ApiManifestBuilder.ts
+++ b/src/router/api/ApiManifestBuilder.ts
@@ -1,0 +1,22 @@
+import type { KairoApiRegistry } from "./KairoApiRegistry";
+import type { ApiManifest } from "./protocol/schema";
+
+export class ApiManifestBuilder {
+    build(registry: KairoApiRegistry): ApiManifest {
+        const apis = registry.getApiNames().map((name) => ({ name }));
+
+        const hooks = registry.getHookDeclarations().map((decl) => {
+            const phases: ("before" | "after")[] = [];
+            if (decl.before) phases.push("before");
+            if (decl.after) phases.push("after");
+            return {
+                targetAddonId: decl.targetAddonId,
+                apiName: decl.apiName,
+                priority: decl.priority,
+                phases,
+            };
+        });
+
+        return { apis, hooks };
+    }
+}

--- a/src/router/api/InvokeHandler.ts
+++ b/src/router/api/InvokeHandler.ts
@@ -1,0 +1,121 @@
+import { compile, safeJsonParse } from "@kairo-js/utils";
+import type { KairoRuntime } from "../../minecraft/KairoRuntime";
+import type { Disposable } from "../types/Disposable";
+import type { KairoApiRegistry } from "./KairoApiRegistry";
+import { ApiHandlerResponseSchema, ApiInvokeSchema, type ApiHandlerResponse, type ApiInvoke } from "./protocol/schema";
+
+export class InvokeHandler implements Disposable {
+    private listener?: Disposable;
+    private disposed = false;
+
+    constructor(
+        private readonly runtime: KairoRuntime,
+        private readonly apiRegistry: KairoApiRegistry,
+        private readonly getKairoKairoId: () => string,
+        private readonly getOwnKairoId: () => string,
+    ) {}
+
+    setup(): void {
+        const ownKairoId = this.getOwnKairoId();
+        this.listener = this.runtime.receive((id, message) => {
+            if (id !== `${ownKairoId}:api-invoke`) return;
+            void this.handleInvoke(message);
+        });
+    }
+
+    dispose(): void {
+        if (this.disposed) return;
+        this.disposed = true;
+        this.listener?.dispose();
+        this.listener = undefined;
+    }
+
+    private async handleInvoke(message: string): Promise<void> {
+        let invoke: ApiInvoke;
+        try {
+            const parsed = safeJsonParse(message, () => new Error("parse failed"));
+            if (!validateApiInvoke(parsed)) {
+                console.warn("[kairo-router] InvokeHandler: invalid ApiInvoke schema");
+                return;
+            }
+            invoke = parsed as ApiInvoke;
+        } catch {
+            console.warn("[kairo-router] InvokeHandler: failed to parse ApiInvoke");
+            return;
+        }
+
+        if (invoke.type === "send") {
+            await this.executeHandler(invoke, false);
+        } else {
+            await this.executeHandler(invoke, true);
+        }
+    }
+
+    private async executeHandler(invoke: ApiInvoke, sendResponse: boolean): Promise<void> {
+        const handler = this.apiRegistry.getApiHandler(invoke.apiName);
+        if (!handler) {
+            if (sendResponse) {
+                this.sendHandlerResponse(invoke.correlationId, false, undefined, `Handler for "${invoke.apiName}" not found`);
+            }
+            return;
+        }
+
+        let args: unknown;
+        try {
+            args = JSON.parse(invoke.args);
+        } catch {
+            if (sendResponse) {
+                this.sendHandlerResponse(invoke.correlationId, false, undefined, "Failed to parse args");
+            }
+            return;
+        }
+
+        let result: unknown;
+        try {
+            result = await handler(args);
+        } catch (e) {
+            if (sendResponse) {
+                const message = e instanceof Error ? e.message : String(e);
+                this.sendHandlerResponse(invoke.correlationId, false, undefined, message);
+            } else {
+                console.warn("[kairo-router] InvokeHandler: handler threw (send mode):", e);
+            }
+            return;
+        }
+
+        if (!sendResponse) return;
+
+        let resultStr: string;
+        try {
+            resultStr = JSON.stringify(result);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : "Result is not JSON serializable";
+            this.sendHandlerResponse(invoke.correlationId, false, undefined, message);
+            return;
+        }
+
+        this.sendHandlerResponse(invoke.correlationId, true, resultStr, undefined);
+    }
+
+    private sendHandlerResponse(
+        correlationId: string,
+        success: boolean,
+        result: string | undefined,
+        error: string | undefined,
+    ): void {
+        const response: ApiHandlerResponse = {
+            correlationId,
+            success,
+            ...(result !== undefined ? { result } : {}),
+            ...(error !== undefined ? { error } : {}),
+            timestamp: this.runtime.currentTick(),
+        };
+        try {
+            this.runtime.send("kairo:api-response", JSON.stringify(response));
+        } catch (e) {
+            console.warn("[kairo-router] InvokeHandler: failed to send ApiHandlerResponse:", e);
+        }
+    }
+}
+
+const validateApiInvoke = compile(ApiInvokeSchema);

--- a/src/router/api/KairoApiRegistry.ts
+++ b/src/router/api/KairoApiRegistry.ts
@@ -1,51 +1,63 @@
 import type { Disposable } from "../types/Disposable";
 
+export type DeepReadonly<T> = T extends readonly (infer U)[]
+    ? ReadonlyArray<DeepReadonly<U>>
+    : T extends object
+    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
+    : T;
+
 export type BeforeHookContext<TArgs, TReturn> = {
     args: TArgs;
-    result: TReturn | undefined;
     readonly callerAddonId: string;
-    cancel(): void;
+    cancel(result?: TReturn): never;
+    setRollbackData(data: unknown): void;
 };
 
 export type AfterHookContext<TArgs, TReturn> = {
-    readonly args: Readonly<TArgs>;
+    readonly args: TArgs;
     result: TReturn;
     readonly callerAddonId: string;
 };
 
 export type HookRollbackContext<TArgs> = {
-    readonly args: Readonly<TArgs>;
+    readonly rollbackData: unknown;
+    readonly currentArgsSnapshot: DeepReadonly<TArgs>;
     readonly callerAddonId: string;
 };
 
 export type HookOptions<TArgs, TReturn> = {
     priority?: number;
-    version?: string;
+    modes?: ReadonlyArray<"send" | "request">;
     before?: (ctx: BeforeHookContext<TArgs, TReturn>) => Promise<void>;
     after?: (ctx: AfterHookContext<TArgs, TReturn>) => Promise<void>;
-    rollback?: (ctx: HookRollbackContext<TArgs>) => Promise<void>;
+    rollback?: (ctx: HookRollbackContext<TArgs>) => Promise<TArgs | void>;
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type ApiHandler = (args: any) => any;
 
+export type HookPhase = "before" | "after";
+
 export type InternalHookDeclaration = {
     readonly targetAddonId: string;
     readonly apiName: string;
     readonly priority: number;
-    readonly version?: string;
+    readonly modes: ReadonlyArray<"send" | "request">;
+    readonly sequence: number;
+    declaringAddonId?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly before?: (ctx: BeforeHookContext<any, any>) => Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly after?: (ctx: AfterHookContext<any, any>) => Promise<void>;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    readonly rollback?: (ctx: HookRollbackContext<any>) => Promise<void>;
+    readonly rollback?: (ctx: HookRollbackContext<any>) => Promise<any | void>;
 };
 
 export class KairoApiRegistry implements Disposable {
     private sealed = false;
     private readonly apiHandlers = new Map<string, ApiHandler>();
     private readonly hookDeclarations: InternalHookDeclaration[] = [];
+    private sequenceCounter = 0;
 
     register<TArgs, TReturn>(
         apiName: string,
@@ -67,11 +79,16 @@ export class KairoApiRegistry implements Disposable {
         if (!options.before && !options.after) {
             throw new Error("[kairo-router] hook must have at least one of before or after");
         }
+
+        const modes: ReadonlyArray<"send" | "request"> =
+            options.modes ?? (options.after ? ["request"] : ["send", "request"]);
+
         this.hookDeclarations.push({
             targetAddonId,
             apiName,
             priority: options.priority ?? 0,
-            version: options.version,
+            modes,
+            sequence: this.sequenceCounter++,
             before: options.before as InternalHookDeclaration["before"],
             after: options.after as InternalHookDeclaration["after"],
             rollback: options.rollback as InternalHookDeclaration["rollback"],
@@ -82,8 +99,20 @@ export class KairoApiRegistry implements Disposable {
         this.sealed = true;
     }
 
-    getApiHandlers(): ReadonlyMap<string, ApiHandler> {
-        return this.apiHandlers;
+    setDeclaringAddonId(addonId: string): void {
+        for (const decl of this.hookDeclarations) {
+            if (!decl.declaringAddonId) {
+                (decl as { declaringAddonId: string }).declaringAddonId = addonId;
+            }
+        }
+    }
+
+    getApiHandler(apiName: string): ApiHandler | undefined {
+        return this.apiHandlers.get(apiName);
+    }
+
+    getApiNames(): ReadonlyArray<string> {
+        return [...this.apiHandlers.keys()];
     }
 
     getHookDeclarations(): readonly InternalHookDeclaration[] {
@@ -96,7 +125,9 @@ export class KairoApiRegistry implements Disposable {
 
     private assertNotSealed(): void {
         if (this.sealed) {
-            throw new Error("[kairo-router] API registration is only allowed during the startup event");
+            throw new Error(
+                "[kairo-router] API registration is only allowed during the startup event",
+            );
         }
     }
 }

--- a/src/router/api/errors.ts
+++ b/src/router/api/errors.ts
@@ -1,0 +1,56 @@
+export class ApiNotFoundError extends Error {
+    constructor(apiName?: string) {
+        super(apiName ? `API "${apiName}" not found` : "API not found");
+        this.name = "ApiNotFoundError";
+    }
+}
+
+export class RequestTimeoutError extends Error {
+    constructor() {
+        super("Request timed out");
+        this.name = "RequestTimeoutError";
+    }
+}
+
+export class BeforeHookExecutionError extends Error {
+    constructor(cause?: unknown) {
+        super("Before hook threw an error");
+        this.name = "BeforeHookExecutionError";
+        if (cause !== undefined) (this as { cause: unknown }).cause = cause;
+    }
+}
+
+export class AfterHookExecutionError extends Error {
+    constructor(cause?: unknown) {
+        super("After hook threw an error");
+        this.name = "AfterHookExecutionError";
+        if (cause !== undefined) (this as { cause: unknown }).cause = cause;
+    }
+}
+
+export class HandlerExecutionError extends Error {
+    constructor(cause?: unknown) {
+        super("Handler threw an error");
+        this.name = "HandlerExecutionError";
+        if (cause !== undefined) (this as { cause: unknown }).cause = cause;
+    }
+}
+
+export type ProtocolStage = "ApiCall" | "ApiInvoke" | "ApiResult" | "ApiHandlerResponse";
+
+export class ProtocolError extends Error {
+    constructor(
+        message: string,
+        readonly source: "local_parse" | "remote",
+        readonly protocolStage?: ProtocolStage,
+        readonly correlationId?: string,
+    ) {
+        super(message);
+        this.name = "ProtocolError";
+    }
+}
+
+export type CancelledResult = {
+    readonly cancelled: true;
+    readonly reason: "ADDON_NOT_FOUND" | "ADDON_INACTIVE" | "ADDON_UNRESOLVED" | "CANCELLED_BY_HOOK";
+};

--- a/src/router/api/protocol/schema.ts
+++ b/src/router/api/protocol/schema.ts
@@ -1,0 +1,84 @@
+import { type Static, Type } from "@sinclair/typebox";
+
+export const ApiCallSchema = Type.Object(
+    {
+        type: Type.Union([Type.Literal("send"), Type.Literal("request")]),
+        correlationId: Type.String(),
+        targetAddonId: Type.String(),
+        apiName: Type.String(),
+        args: Type.String(),
+        timeout: Type.Optional(Type.Integer({ minimum: 1 })),
+        timestamp: Type.Integer({ minimum: 0 }),
+    },
+    { additionalProperties: false },
+);
+
+export const ApiInvokeSchema = Type.Object(
+    {
+        type: Type.Union([Type.Literal("send"), Type.Literal("request")]),
+        correlationId: Type.String(),
+        callerAddonId: Type.String(),
+        apiName: Type.String(),
+        args: Type.String(),
+        timestamp: Type.Integer({ minimum: 0 }),
+    },
+    { additionalProperties: false },
+);
+
+export const ApiHandlerResponseSchema = Type.Object(
+    {
+        correlationId: Type.String(),
+        success: Type.Boolean(),
+        result: Type.Optional(Type.String()),
+        error: Type.Optional(Type.String()),
+        timestamp: Type.Integer({ minimum: 0 }),
+    },
+    { additionalProperties: false },
+);
+
+export const ApiResultSchema = Type.Object(
+    {
+        correlationId: Type.String(),
+        success: Type.Boolean(),
+        result: Type.Optional(Type.String()),
+        cancelled: Type.Optional(Type.Literal(true)),
+        reason: Type.Optional(Type.String()),
+        errorType: Type.Optional(
+            Type.Union([
+                Type.Literal("API_NOT_FOUND"),
+                Type.Literal("BEFORE_HOOK_EXECUTION"),
+                Type.Literal("AFTER_HOOK_EXECUTION"),
+                Type.Literal("HANDLER_EXECUTION"),
+                Type.Literal("TIMEOUT"),
+                Type.Literal("PROTOCOL_ERROR"),
+            ]),
+        ),
+        error: Type.Optional(Type.String()),
+        timestamp: Type.Integer({ minimum: 0 }),
+    },
+    { additionalProperties: false },
+);
+
+export type ApiCall = Static<typeof ApiCallSchema>;
+export type ApiInvoke = Static<typeof ApiInvokeSchema>;
+export type ApiHandlerResponse = Static<typeof ApiHandlerResponseSchema>;
+export type ApiResult = Static<typeof ApiResultSchema>;
+
+export const ApiManifestSchema = Type.Object(
+    {
+        apis: Type.Array(Type.Object({ name: Type.String() })),
+        hooks: Type.Array(
+            Type.Object({
+                targetAddonId: Type.String(),
+                apiName: Type.String(),
+                priority: Type.Integer({ minimum: -2147483648, maximum: 2147483647 }),
+                phases: Type.Array(
+                    Type.Union([Type.Literal("before"), Type.Literal("after")]),
+                ),
+            }),
+        ),
+    },
+    { additionalProperties: false },
+);
+
+export type ApiManifest = Static<typeof ApiManifestSchema>;

--- a/src/router/init/KairoInitializer.ts
+++ b/src/router/init/KairoInitializer.ts
@@ -1,5 +1,6 @@
 import { type Random } from "@kairo-js/utils";
 import { KairoRuntime } from "../../minecraft/KairoRuntime";
+import type { KairoApiRegistry } from "../api/KairoApiRegistry";
 import type { KairoContext, KairoContextMutator } from "../KairoContext";
 import { ReadyState } from "../ReadyState";
 import type { Disposable } from "../types/Disposable";
@@ -36,6 +37,7 @@ export class KairoInitializer implements Disposable {
         private readonly contextMutator: KairoContextMutator,
         private readonly random: Random,
         private readonly readyState: ReadyState,
+        private readonly apiRegistry: KairoApiRegistry,
         private readonly onCompleted?: () => void,
         private readonly onDisposed?: () => void,
     ) {
@@ -44,7 +46,7 @@ export class KairoInitializer implements Disposable {
 
         this.discoveryController = new DiscoveryController(this.idProvider);
 
-        this.registrationController = new RegistrationController(this.registryBuilder);
+        this.registrationController = new RegistrationController(this.registryBuilder, this.apiRegistry);
 
         this.initListener = new KairoInitListener(this.readyState, {
             [KairoInitEventId.DiscoveryQuery]: this.handleDiscoveryQuery,

--- a/src/router/init/registration/RegistrationController.ts
+++ b/src/router/init/registration/RegistrationController.ts
@@ -1,4 +1,5 @@
 import { KairoRuntime } from "../../../minecraft/KairoRuntime";
+import type { KairoApiRegistry } from "../../api/KairoApiRegistry";
 import { KairoContext, type KairoContextMutator } from "../../KairoContext";
 import type { KairoRegistry } from "../../types/KairoRegistry";
 import { KairoRegistryBuilder } from "../KairoRegistryBuilder";
@@ -9,7 +10,10 @@ export class RegistrationController {
     private readonly registrationManager: AddonRegistrationManager;
     private readonly registrationResponder: RegistrationResponder;
 
-    constructor(private readonly registryBuilder: KairoRegistryBuilder) {
+    constructor(
+        private readonly registryBuilder: KairoRegistryBuilder,
+        private readonly apiRegistry: KairoApiRegistry,
+    ) {
         this.registrationManager = new AddonRegistrationManager(this.registryBuilder);
         this.registrationResponder = new RegistrationResponder();
     }
@@ -27,8 +31,10 @@ export class RegistrationController {
 
         if (!registry) return;
 
-        this.registrationResponder.respond(deps.runtime, registry);
+        this.registrationResponder.respond(deps.runtime, registry, this.apiRegistry);
         deps.contextMutator.setKairoRegistry(registry);
+
+        this.apiRegistry.setDeclaringAddonId(registry.addonId);
 
         return registry;
     };

--- a/src/router/init/registration/RegistrationResponder.ts
+++ b/src/router/init/registration/RegistrationResponder.ts
@@ -1,5 +1,7 @@
 import { toError } from "@kairo-js/utils";
 import { KairoRuntime } from "../../../minecraft/KairoRuntime";
+import type { KairoApiRegistry } from "../../api/KairoApiRegistry";
+import { ApiManifestBuilder } from "../../api/ApiManifestBuilder";
 import type { KairoRegistry } from "../../types/KairoRegistry";
 import { KairoInitEventId } from "../constants/KairoInitEventId";
 import { RegistrationResponseError, RegistrationResponseErrorReason } from "./response/errors";
@@ -8,17 +10,19 @@ import { stringifyRegistrationResponse } from "./response/stringify";
 
 // kjs-router-ch 0203
 export class RegistrationResponder {
-    constructor() {}
+    private readonly manifestBuilder = new ApiManifestBuilder();
 
-    respond(runtime: KairoRuntime, kairoRegistry: KairoRegistry): void {
+    respond(runtime: KairoRuntime, kairoRegistry: KairoRegistry, apiRegistry: KairoApiRegistry): void {
+        const apiManifest = this.manifestBuilder.build(apiRegistry);
+
         const response: RegistrationResponse = {
             kairoRegistry,
+            apiManifest,
             timestamp: runtime.currentTick(),
         };
 
         try {
             const responseStr = stringifyRegistrationResponse(response);
-
             runtime.send(KairoInitEventId.RegistrationResponse, responseStr);
         } catch (e: unknown) {
             throw new RegistrationResponseError(RegistrationResponseErrorReason.StringifyFailed, {

--- a/src/router/init/registration/response/schema.ts
+++ b/src/router/init/registration/response/schema.ts
@@ -27,6 +27,19 @@ export const RegistrationResponseSchema = Type.Object(
             optionalDependencies: Type.Readonly(Type.Record(Type.String(), Type.String())),
             tags: Type.Readonly(Type.Array(Type.String())),
         }),
+        apiManifest: Type.Object({
+            apis: Type.Array(Type.Object({ name: Type.String() })),
+            hooks: Type.Array(
+                Type.Object({
+                    targetAddonId: Type.String(),
+                    apiName: Type.String(),
+                    priority: Type.Integer({ minimum: -2147483648, maximum: 2147483647 }),
+                    phases: Type.Array(
+                        Type.Union([Type.Literal("before"), Type.Literal("after")]),
+                    ),
+                }),
+            ),
+        }),
         timestamp: Type.Integer({ minimum: 0 }),
     },
     {


### PR DESCRIPTION
## Summary

アドオン間 API 呼び出しを kairo がルーティングする仕組みを実装した。

`API_SPEC.md` で定義されたプロトコルに基づき、アドオン開発者が `router.send()` / `router.request()` で他アドオンの API を呼び出せるようになる。呼び出し元は相手の `addonId` と API 名だけ知っていればよく、`kairoId` や ScriptEvent の詳細は意識しない。

## Changes

### Public API（`@kairo-js/router`）

- **`router.send(targetAddonId, apiName, args?)`** — fire-and-forget 呼び出し。エラーはすべてサイレント
- **`router.request<TReturn>(targetAddonId, apiName, args?, options?)`** — 結果を待つ呼び出し。`CancelledResult` または reject で失敗を通知
- **`ev.api.register(apiName, handler)`** — startup イベント内でのみ API を登録可能
- **`ev.api.hook(targetAddonId, apiName, options)`** — before / after / rollback hook。priority・modes 指定あり

### Protocol（ScriptEvent）

| 方向 | Event ID | 用途 |
|---|---|---|
| Router → Kairo | `kairo:api-call` | send / request の呼び出し |
| Kairo → Router | `{kairoId}:api-invoke` | handler への実行指示 |
| Router → Kairo | `kairo:api-response` | handler 結果の返送 |
| Kairo → Router | `{correlationId}:api-result` | request の最終結果 |

### 型・エラークラス

- `CancelledResult` — addon 状態（NOT_FOUND / INACTIVE / UNRESOLVED）や hook cancel を表す
- `ApiNotFoundError` / `RequestTimeoutError` / `BeforeHookExecutionError` / `AfterHookExecutionError` / `HandlerExecutionError` / `ProtocolError`
- `DeepReadonly<T>` / `HookOptions.modes` / `BeforeHookContext.cancel(result?): never` / `BeforeHookContext.setRollbackData()` / `HookRollbackContext.rollbackData` + `currentArgsSnapshot`

### Registration 変更

`RegistrationResponse` に `apiManifest` フィールドを追加。kairo 側がルーティングテーブルとフックテーブルを構築するために使用する。

```ts
apiManifest: {
  apis:  [{ name: string }]
  hooks: [{ targetAddonId, apiName, priority, phases }]
}

Test plan

- [ ] router.request() が正常系で TReturn を返す
- [ ] 対象 addon が inactive のとき { cancelled: true, reason: "ADDON_INACTIVE" } が返る
- [ ] hook が ctx.cancel() を呼んだとき CANCELLED_BY_HOOK が返る
- [ ] hook が ctx.cancel(result) を呼んだとき handler をスキップして result が返る
- [ ] before hook が例外をスローしたとき rollback が逆順実行され BeforeHookExecutionError で reject される
- [ ] after hook が例外をスローしたとき AfterHookExecutionError で reject される
- [ ] タイムアウト到達で RequestTimeoutError が返る
- [ ] router.send() はエラー・キャンセルをすべて無視してサイレントに完了する
- [ ] RegistrationResponse に apiManifest が含まれる（既存の Registration フローが壊れていない）

🤖 Generated with Claude Code (https://claude.com/claude-code)